### PR TITLE
refactor(config): move agent behavior flags from CLI to workflow.yaml settings

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,18 +28,18 @@ The daemon is stoppable and restartable without losing track of in-flight work.
 State is persisted to ~/.plural/daemon-state.json.
 
 If --repo is not specified and the current directory is inside a git repository,
-that repository is used as the default. Auto-merge is enabled by default;
-use --no-auto-merge to disable.
+that repository is used as the default.
+
+Behavior is configured via .plural/workflow.yaml in your repository. Settings such
+as max_turns, max_duration, merge_method, and auto_merge can all be specified there.
 
 All sessions are containerized (container = sandbox).
 
 Examples:
-  plural-agent                                    # Use current git repo as default
-  plural-agent --repo owner/repo                  # Run daemon (long-running, auto-merge on)
-  plural-agent --repo owner/repo --once           # Process one tick and exit
-  plural-agent --repo /path/to/repo               # Use filesystem path instead
-  plural-agent --repo owner/repo --no-auto-merge  # Disable auto-merge
-  plural-agent --repo owner/repo --max-turns 100`,
+  plural-agent                          # Use current git repo as default
+  plural-agent --repo owner/repo        # Run daemon (long-running)
+  plural-agent --repo owner/repo --once # Process one tick and exit
+  plural-agent --repo /path/to/repo     # Use filesystem path instead`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/internal/agentconfig/agent_config.go
+++ b/internal/agentconfig/agent_config.go
@@ -63,6 +63,21 @@ func WithMaxConcurrent(max int) AgentConfigOption {
 	return func(c *AgentConfig) { c.maxConcurrent = max }
 }
 
+// WithMaxTurns sets the max autonomous turns per session.
+func WithMaxTurns(max int) AgentConfigOption {
+	return func(c *AgentConfig) { c.maxTurns = max }
+}
+
+// WithMaxDuration sets the max autonomous duration in minutes per session.
+func WithMaxDuration(max int) AgentConfigOption {
+	return func(c *AgentConfig) { c.maxDurationMin = max }
+}
+
+// WithMergeMethod sets the merge method (rebase, squash, or merge).
+func WithMergeMethod(method string) AgentConfigOption {
+	return func(c *AgentConfig) { c.mergeMethod = method }
+}
+
 // NewAgentConfig creates a new AgentConfig with defaults, then applies options.
 func NewAgentConfig(opts ...AgentConfigOption) *AgentConfig {
 	c := &AgentConfig{

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -34,6 +34,10 @@ type SettingsConfig struct {
 	BranchPrefix   string `yaml:"branch_prefix,omitempty"`
 	MaxConcurrent  int    `yaml:"max_concurrent,omitempty"`
 	CleanupMerged  *bool  `yaml:"cleanup_merged,omitempty"`
+	MaxTurns       int    `yaml:"max_turns,omitempty"`
+	MaxDuration    int    `yaml:"max_duration,omitempty"` // minutes
+	AutoMerge      *bool  `yaml:"auto_merge,omitempty"`
+	MergeMethod    string `yaml:"merge_method,omitempty"`
 }
 
 // State represents a single node in the workflow graph.


### PR DESCRIPTION
## Summary
Removes CLI flags for agent behavior configuration (max-turns, max-duration, merge-method, auto-merge, etc.) and consolidates them into the `.plural/workflow.yaml` settings block, simplifying the CLI interface and making per-repo configuration the primary mechanism.

## Changes
- Remove CLI flags: `--max-concurrent`, `--max-turns`, `--max-duration`, `--auto-merge`, `--no-auto-merge`, `--merge-method`, `--auto-address-pr-comments`, `--auto-broadcast-pr`
- Add `max_turns`, `max_duration`, `auto_merge`, and `merge_method` fields to `SettingsConfig` in the workflow config
- Add `WithMaxTurns`, `WithMaxDuration`, and `WithMergeMethod` option functions to `agentconfig`
- Wire workflow settings into agent config during startup in `cmd/agent.go`
- Update README to reflect the simplified CLI and document the new `settings:` block
- Update override precedence: workflow.yaml settings > config.json > defaults (CLI flags no longer in the chain)

## Test plan
- Run `go test ./...` to verify all existing tests pass
- Verify `plural-agent --help` no longer shows removed flags
- Test with a `.plural/workflow.yaml` containing `settings:` block to confirm values are picked up
- Test without workflow.yaml to confirm config.json defaults still apply

Fixes #2