### PR TITLE
fix: prevent duplicate PRs from API errors and MCP tool calls

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -227,6 +227,7 @@ func (d *Daemon) collectCompletedWorkers(ctx context.Context) {
 			// Feedback addressing completed — push changes (skip if worker failed)
 			if exitErr != nil {
 				d.logger.Warn("skipping push after failed feedback session", "workItem", workItemID, "error", exitErr)
+				d.state.SetErrorMessage(item.ID, fmt.Sprintf("feedback session failed: %v", exitErr))
 				item.Phase = "idle"
 				item.UpdatedAt = time.Now()
 			} else {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1012,4 +1012,8 @@ func TestDaemon_CollectCompletedWorkers_FeedbackError(t *testing.T) {
 	if item.IsTerminal() {
 		t.Error("expected non-terminal state — failed feedback should not kill the work item")
 	}
+	// Error message should be persisted for operator visibility
+	if item.ErrorMessage == "" {
+		t.Error("expected error message to be set after failed feedback")
+	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -417,10 +417,15 @@ func (w *SessionWorker) handleStreaming(chunk claude.ResponseChunk) {
 }
 
 // isAPIErrorContent returns true if the streamed text content looks like an
-// API error response (e.g., "API Error: 500 {...}").
+// API error response (e.g., "API Error: 500 {"type":"error",...}").
+// We require both the "API Error:" prefix AND a JSON error structure
+// to avoid false positives on normal text that happens to mention API errors.
 func isAPIErrorContent(content string) bool {
-	return strings.HasPrefix(content, "API Error:") ||
-		strings.HasPrefix(content, "API error:")
+	if !strings.HasPrefix(content, "API Error:") && !strings.HasPrefix(content, "API error:") {
+		return false
+	}
+	return strings.Contains(content, `"type":"error"`) ||
+		strings.Contains(content, `"type": "error"`)
 }
 
 // handleDone handles completion of a streaming response.

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -299,10 +299,12 @@ func TestIsAPIErrorContent(t *testing.T) {
 		content string
 		want    bool
 	}{
-		{"API Error 500", `API Error: 500 {"type":"error"}`, true},
-		{"API error lowercase", `API error: 429 rate limited`, true},
+		{"API Error 500 with JSON", `API Error: 500 {"type":"error","error":{"type":"api_error","message":"Internal server error"}}`, true},
+		{"API error lowercase with JSON", `API error: 429 {"type":"error","error":{"type":"rate_limit_error"}}`, true},
+		{"API Error with spaced JSON", `API Error: 500 {"type": "error", "message": "fail"}`, true},
+		{"API Error without JSON structure", `API Error: The user encountered a 500`, false},
 		{"normal content", "Here is the code I wrote", false},
-		{"error in middle", "The API Error: 500 happened", false},
+		{"error in middle", `The API Error: 500 {"type":"error"} happened`, false},
 		{"empty", "", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- **Detect API errors in streamed content**: Worker now flags API 500 errors emitted as text (rather than `chunk.Error`) and treats them as session failures instead of successes. The daemon passes `success=false` to the workflow engine, routing to the `failed` state instead of advancing to PR creation.
- **Block create_pr/push_branch MCP tools in daemon-managed mode**: Claude's attempts to create PRs or push branches via MCP are rejected with a clear error message, since the daemon's workflow handles these operations.
- **Graceful feedback failure handling**: If a feedback-addressing session fails, the daemon skips the push and returns the work item to `idle` phase so review polling continues.

## Test plan

- [x] `TestSessionWorker_ExitError_NilOnSuccess` — ExitError is nil after normal completion
- [x] `TestSessionWorker_ExitError_SetOnChunkError` — ExitError set on chunk.Error
- [x] `TestSessionWorker_ExitError_APIErrorInStream` — ExitError set when API error detected in streamed text
- [x] `TestIsAPIErrorContent` — table-driven tests for API error pattern detection
- [x] `TestNewDoneWorkerWithError` — constructor for test support
- [x] `TestSessionWorker_HandleCreatePR_DaemonManaged` — create_pr rejected in daemon mode
- [x] `TestSessionWorker_HandlePushBranch_DaemonManaged` — push_branch rejected in daemon mode
- [x] `TestDaemon_CollectCompletedWorkers_WorkerError` — failed worker routes to failed state
- [x] `TestDaemon_CollectCompletedWorkers_FeedbackError` — failed feedback skips push, returns to idle
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)