### PR TITLE
docs: fix step data keys and add step data reference

### DIFF
--- a/internal/workflow/init.go
+++ b/internal/workflow/init.go
@@ -106,13 +106,13 @@ states:
   # check_result:
   #   type: choice
   #   choices:
-  #     - variable: ci_status    # Step data key to evaluate
-  #       equals: passing        # Condition: equals, not_equals, or is_present
+  #     - variable: ci_passed        # Step data key set by ci.complete event
+  #       equals: true               # Condition: equals, not_equals, or is_present
   #       next: merge
-  #     - variable: ci_status
-  #       equals: failing
-  #       next: fix_ci
-  #   default: await_ci          # Fallback if no rule matches
+  #     - variable: pr_merged_externally  # Step data key set by pr.reviewed event
+  #       equals: true
+  #       next: done
+  #   default: await_ci              # Fallback if no rule matches
 
   # --- Example: pass state (data injection) ---
   # set_defaults:


### PR DESCRIPTION
## Summary
- Fixed choice state examples in `init.go` template and `README.md` that used fictional `ci_status` keys — replaced with actual keys returned by event handlers (`ci_passed`, `pr_merged_externally`, etc.)
- Added a **Step Data Reference** section to README documenting every key that actions, events, timeouts, and the engine write into step data, so users can build custom workflows with choice states that actually work

## Test plan
- [x] `go test ./...` passes
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)