### PR TITLE
fix: recover from stale branches and harden daemon resilience

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -48,6 +48,11 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("docker is required for agent mode.\nInstall: https://docs.docker.com/get-docker/")
 	}
 
+	// Verify Docker daemon is actually running (not just binary present)
+	if err := checkDockerDaemon(); err != nil {
+		return err
+	}
+
 	// Enable debug logging for agent mode (always on for headless autonomous operation)
 	logger.SetDebug(true)
 

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -106,3 +106,33 @@ func TestResolveAgentRepo_RealGitRepo(t *testing.T) {
 		t.Errorf("resolveAgentRepo = %q, want %q", resolved, expectedRoot)
 	}
 }
+
+func TestCheckDockerDaemon(t *testing.T) {
+	// Skip if docker binary isn't installed — nothing to test.
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not installed, skipping")
+	}
+
+	err := checkDockerDaemon()
+	// We can't assert success/failure portably (depends on whether Docker
+	// daemon is running in the test environment), but we CAN verify the
+	// function returns a non-nil error with a helpful message when it fails.
+	if err != nil {
+		if !containsAny(err.Error(), "not reachable", "Colima", "Docker Desktop") {
+			t.Errorf("expected helpful error message, got: %v", err)
+		}
+	}
+}
+
+func containsAny(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if len(s) >= len(sub) {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,10 +2,25 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
+	"os/exec"
 	"strings"
+	"time"
 )
+
+// checkDockerDaemon verifies the Docker daemon is reachable, not just that
+// the binary exists. This catches the case where Docker/Colima is installed
+// but not running, which would otherwise cause silent per-session failures.
+func checkDockerDaemon() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "docker", "info").Run(); err != nil {
+		return fmt.Errorf("docker daemon is not reachable (is Colima or Docker Desktop running?)\n\nStart with: colima start")
+	}
+	return nil
+}
 
 // confirm prompts the user for y/n confirmation
 func confirm(input io.Reader, prompt string) bool {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -351,6 +351,21 @@ func (d *Daemon) executeSyncChain(ctx context.Context, item *daemonstate.WorkIte
 		if result.Terminal {
 			d.state.AdvanceWorkItem(item.ID, result.NewStep, result.NewPhase)
 			d.state.MarkWorkItemTerminal(item.ID, result.TerminalOK)
+			if !result.TerminalOK {
+				errMsg := ""
+				if e, ok := item.StepData["_last_error"].(string); ok {
+					errMsg = e
+				}
+				if errMsg == "" {
+					if e, ok := result.Data["_last_error"].(string); ok {
+						errMsg = e
+					}
+				}
+				if errMsg != "" {
+					d.state.SetErrorMessage(item.ID, errMsg)
+				}
+				d.logger.Error("work item failed", "workItem", item.ID, "step", item.CurrentStep, "error", errMsg)
+			}
 			return
 		}
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -396,10 +396,13 @@ func (e *Engine) handleFailure(item *WorkItemView, state *State, errStr string, 
 
 	// Fall back to error edge
 	if state.Error != "" {
+		errorData := mergeData(data, map[string]any{
+			"_last_error": errStr,
+		})
 		return &StepResult{
 			NewStep:  state.Error,
 			NewPhase: "idle",
-			Data:     data,
+			Data:     errorData,
 			Hooks:    state.After,
 		}, nil
 	}


### PR DESCRIPTION
## Summary

- **Stale branch recovery**: When the daemon crashes mid-session, recovery re-queues the work item but leaves the branch on disk. Previously `startCoding` would fail permanently on the existing branch. Now it automatically cleans up stale branches (via session cleanup or direct git fallback) before creating a fresh session.
- **Docker daemon check**: Adds a reachability check (`docker info`) at agent startup so users get a clear error ("is Colima or Docker Desktop running?") instead of silent per-session failures.
- **Re-queue cooldown**: `HasWorkItemForIssue` now returns true for recently-failed items (5-minute cooldown), preventing infinite re-queue storms when an issue persistently fails.
- **Error propagation**: Workflow engine error edges now carry `_last_error` in step data, and `executeSyncChain` surfaces it on terminal failures for better diagnostics.

## Test plan

- [x] `TestStartCoding_CleansUpStaleBranch` — stale session cleanup path
- [x] `TestStartCoding_CleansUpOrphanedBranch` — orphaned branch git cleanup path
- [x] `TestStartCoding_FailsWhenCleanupFails` — error when cleanup cannot remove branch
- [x] `TestParseWorktreeForBranch` — porcelain output parser (table-driven)
- [x] `TestCheckDockerDaemon` — Docker reachability check
- [x] `TestDaemonState_HasWorkItemForIssue` — expanded table-driven tests including cooldown
- [x] `go test ./...` — all tests pass
- [x] `go build -o plural-agent .` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)