### PR TITLE
fix: include issue body in initial message sent to Claude

### DIFF
--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -213,7 +213,8 @@ func (d *Daemon) startCoding(ctx context.Context, item *daemonstate.WorkItem) er
 	item.UpdatedAt = time.Now()
 
 	// Build initial message using provider-aware formatting
-	initialMsg := worker.FormatInitialMessage(item.IssueRef)
+	issueBody, _ := item.StepData["issue_body"].(string)
+	initialMsg := worker.FormatInitialMessage(item.IssueRef, issueBody)
 
 	// Resolve coding system prompt from workflow config
 	systemPrompt := params.String("system_prompt", "")

--- a/internal/daemon/polling.go
+++ b/internal/daemon/polling.go
@@ -89,6 +89,10 @@ func (d *Daemon) pollForNewIssues(ctx context.Context) {
 					Title:  issue.Title,
 					URL:    issue.URL,
 				},
+				StepData: map[string]any{},
+			}
+			if issue.Body != "" {
+				item.StepData["issue_body"] = issue.Body
 			}
 
 			d.state.AddWorkItem(item)

--- a/internal/worker/helpers.go
+++ b/internal/worker/helpers.go
@@ -45,17 +45,24 @@ func FormatPRCommentsPrompt(comments []git.PRReviewComment) string {
 }
 
 // FormatInitialMessage formats the initial message for a coding session based on the issue provider.
-func FormatInitialMessage(ref config.IssueRef) string {
+// The optional body parameter contains the issue description/body text.
+func FormatInitialMessage(ref config.IssueRef, body string) string {
 	provider := issues.Source(ref.Source)
 
+	var header string
 	switch provider {
 	case issues.SourceGitHub:
-		return fmt.Sprintf("GitHub Issue #%s: %s\n\n%s", ref.ID, ref.Title, ref.URL)
+		header = fmt.Sprintf("GitHub Issue #%s: %s\n\n%s", ref.ID, ref.Title, ref.URL)
 	case issues.SourceAsana:
-		return fmt.Sprintf("Asana Task: %s\n\n%s", ref.Title, ref.URL)
+		header = fmt.Sprintf("Asana Task: %s\n\n%s", ref.Title, ref.URL)
 	case issues.SourceLinear:
-		return fmt.Sprintf("Linear Issue %s: %s\n\n%s", ref.ID, ref.Title, ref.URL)
+		header = fmt.Sprintf("Linear Issue %s: %s\n\n%s", ref.ID, ref.Title, ref.URL)
 	default:
-		return fmt.Sprintf("Issue %s: %s\n\n%s", ref.ID, ref.Title, ref.URL)
+		header = fmt.Sprintf("Issue %s: %s\n\n%s", ref.ID, ref.Title, ref.URL)
 	}
+
+	if body != "" {
+		return header + "\n\n" + body
+	}
+	return header
 }


### PR DESCRIPTION
## Summary
When creating a coding session, the issue body/description was not being passed to Claude. This meant Claude only saw the issue title and URL, missing important context from the issue description.

## Changes
- Store issue body in `StepData["issue_body"]` during polling when the body is non-empty
- Update `FormatInitialMessage` to accept and append the issue body after the URL
- Update `startCoding` to extract the issue body from step data and pass it to the formatter
- Add tests for body storage in polling, body inclusion in formatted messages, and body placement

## Test plan
- `go test ./internal/daemon/...` — verifies issue body is stored in StepData during polling (including empty body case)
- `go test ./internal/worker/...` — verifies FormatInitialMessage includes body for all providers and omits it when empty

Fixes #10