### PR TITLE
fix: mitigate container segfaults and include issue body in sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,17 @@ Guidance for Claude Code when working with this repository.
 
 - Every new function or method must have corresponding unit tests
 - Every bug fix must include a regression test
-- Run `go test ./...` before considering any task complete
+- Run `go test -p=1 -count=1 ./...` before considering any task complete
 - Aim for high coverage (80%+) on new code
 - Use table-driven tests where appropriate
 - Test edge cases and error conditions, not just happy paths
+- If `go test` fails with a segfault or signal, retry — it may be a transient container issue
 
 ## Build and Run
 
 ```bash
 go build -o plural-agent .       # Build
-go test ./...                    # Test
+go test -p=1 -count=1 ./...     # Test (use -p=1 in containers to avoid Go toolchain segfaults)
 
 ./plural-agent --version         # Show version
 ./plural-agent --debug           # Enable debug logging (on by default)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	go build -o plural-agent .
 
 test:
-	go test -count=1 ./...
+	go test -p=1 -count=1 ./...
 
 clean:
 	go clean -cache

--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -36,7 +36,15 @@ WORKFLOW:
 2. Implement the changes with clean, well-tested code
 3. Run tests to verify your changes work
 4. Commit your changes locally with a clear commit message
-5. Stop when the implementation is complete — the system will handle pushing and PR creation`
+5. Stop when the implementation is complete — the system will handle pushing and PR creation
+
+CONTAINER ENVIRONMENT:
+You are running inside a Docker container. The Go toolchain may intermittently segfault
+due to container resource constraints. To mitigate this:
+- For Go projects, always run tests with: go test -p=1 -count=1 ./...
+  The -p=1 flag limits parallel package compilation to reduce memory pressure.
+- If a build or test command fails with a signal (segfault, SIGBUS, signal: killed),
+  retry the command up to 2 times — the failure is likely transient.`
 
 // codingAction implements the ai.code action.
 type codingAction struct {

--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -352,6 +352,23 @@ func TestDefaultCodingSystemPrompt_Applied(t *testing.T) {
 	}
 }
 
+func TestDefaultCodingSystemPrompt_ContainerEnvironment(t *testing.T) {
+	// The system prompt should include container environment guidance
+	// to mitigate Go toolchain segfaults in containerized sessions.
+	if !strings.Contains(DefaultCodingSystemPrompt, "CONTAINER ENVIRONMENT") {
+		t.Error("DefaultCodingSystemPrompt should contain CONTAINER ENVIRONMENT section")
+	}
+	if !strings.Contains(DefaultCodingSystemPrompt, "-p=1") {
+		t.Error("DefaultCodingSystemPrompt should recommend -p=1 for Go test parallelism")
+	}
+	if !strings.Contains(DefaultCodingSystemPrompt, "segfault") {
+		t.Error("DefaultCodingSystemPrompt should mention segfault as a transient failure")
+	}
+	if !strings.Contains(DefaultCodingSystemPrompt, "retry") {
+		t.Error("DefaultCodingSystemPrompt should recommend retrying on transient failures")
+	}
+}
+
 func TestDefaultCodingSystemPrompt_NotAppliedWhenCustomSet(t *testing.T) {
 	// Simulate the logic: when a custom prompt is set, DefaultCodingSystemPrompt is NOT used
 	customPrompt := "My custom coding instructions"


### PR DESCRIPTION
## Summary
Two fixes for containerized agent sessions: mitigates intermittent Go toolchain segfaults by limiting parallel compilation, and ensures issue body text is passed through to Claude coding sessions.

## Changes
- Add `-p=1` flag to all `go test` invocations (Makefile, CLAUDE.md) to reduce memory pressure in containers
- Add container environment guidance to the default coding system prompt, instructing Claude to use `-p=1` and retry transient segfaults
- Store issue body in `StepData["issue_body"]` during polling
- Update `FormatInitialMessage` to accept and append the issue body to the initial coding session message
- Add tests for container environment prompt content, issue body storage in step data, and body formatting in initial messages

## Test plan
- `go test -p=1 -count=1 ./...` — all existing and new tests pass
- `TestDefaultCodingSystemPrompt_ContainerEnvironment` verifies the system prompt contains container guidance
- `TestPollForNewIssues_StoresBodyInStepData` verifies issue body is stored/omitted correctly
- `TestFormatInitialMessage_BodyPlacement` verifies body is appended after the URL or omitted when empty
- Verify in a containerized session that Claude receives the issue body and container environment instructions

Fixes #9