### PR TITLE
docs: update README.md and CLAUDE.md to reflect current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ For complex issues, Claude can delegate subtasks to child sessions via MCP tools
 plural-agent --repo owner/repo        # Required: repo to poll
 plural-agent --repo owner/repo --once # Single tick, then exit
 
+# Workflow management
+plural-agent workflow init                    # Generate .plural/workflow.yaml template
+plural-agent workflow init --repo /path/to/repo
+plural-agent workflow validate                # Validate workflow configuration
+plural-agent workflow validate --repo /path/to/repo
+plural-agent workflow visualize               # Print mermaid diagram of workflow
+
 # Cleanup
 plural-agent clean                    # Remove daemon state and lock files
 plural-agent clean -y                 # Clean without confirmation


### PR DESCRIPTION
## Summary
Updates project documentation to accurately reflect the current codebase structure, including the workflow package, new daemon file organization, and workflow CLI subcommands.

## Changes
- Add `cmd/workflow.go` and `internal/workflow/` package file listings to CLAUDE.md
- Document new daemon file split (`host.go`, `lifecycle.go`) in CLAUDE.md
- Update import graph to include `cmd/workflow.go` and `workflow/` leaf dependency
- Add `gopkg.in/yaml.v3` to key dependencies
- Add workflow CLI subcommands (`init`, `validate`, `visualize`) to README.md usage section

## Test plan
- Documentation-only change; no code modified
- Verify markdown renders correctly on GitHub

Fixes #20