### PR TITLE
feat: support Colima as a container runtime alongside Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,22 @@ coding ──► open_pr ──► await_review ──► await_ci ──► mer
 | `done` | succeed | -- | -- | -- |
 | `failed` | fail | -- | -- | -- |
 
+```mermaid
+stateDiagram-v2
+    [*] --> coding
+    coding --> open_pr : ai.code
+    coding --> failed : error
+    open_pr --> await_review : github.create_pr
+    open_pr --> failed : error
+    await_review --> await_ci : pr.reviewed
+    await_review --> failed : error
+    await_ci --> merge : ci.complete (timeout: 2h0m0s)
+    await_ci --> failed : error
+    merge --> done : github.merge
+    done --> [*]
+    failed --> [*]
+```
+
 **Fast-path shortcuts:** If the Claude session itself creates a PR (via MCP tools during coding), the daemon detects this and skips `open_pr`, advancing directly to `await_review`. If the session also merges, it skips straight to `done`.
 
 ---


### PR DESCRIPTION
## Summary
Adds Colima as a supported container runtime alternative to Docker Desktop. Previously, the agent required Docker specifically; now either Docker or Colima on PATH satisfies the container runtime requirement.

## Changes
- Add `hasContainerRuntime()` check that accepts either `docker` or `colima` on PATH
- Improve error messages with context-aware hints (suggests `colima start` if colima is installed, otherwise shows install links for both runtimes)
- Make Docker a recommended (not required) Homebrew dependency in goreleaser config
- Update README prerequisites to list both Docker Desktop and Colima as options
- Add mermaid state diagram to README default workflow section
- Add comprehensive tests for runtime detection and hint logic

## Test plan
- Run `go test -p=1 -count=1 ./cmd/...` to verify new tests pass
- Test on a machine with only Colima installed — agent should start successfully
- Test on a machine with only Docker installed — agent should start successfully
- Test with neither installed — agent should show install links for both runtimes
- Test with Colima installed but not running — should suggest `colima start`

Fixes #26