### PR TITLE
fix: filter out session transcript comments when addressing review feedback

### DIFF
--- a/internal/worker/helpers.go
+++ b/internal/worker/helpers.go
@@ -44,6 +44,24 @@ func FormatPRCommentsPrompt(comments []git.PRReviewComment) string {
 	return sb.String()
 }
 
+// TranscriptMarker is the HTML marker used to identify session transcript comments
+// posted by UploadTranscriptToPR in plural-core. These are collapsible <details> blocks
+// containing the coding session transcript.
+const TranscriptMarker = "<summary>Session Transcript</summary>"
+
+// FilterTranscriptComments removes session transcript comments from a slice of PR review comments.
+// The daemon automatically posts a coding transcript as a PR comment; this transcript
+// should not be treated as review feedback when addressing reviewer comments.
+func FilterTranscriptComments(comments []git.PRReviewComment) []git.PRReviewComment {
+	filtered := make([]git.PRReviewComment, 0, len(comments))
+	for _, c := range comments {
+		if !strings.Contains(c.Body, TranscriptMarker) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
 // FormatInitialMessage formats the initial message for a coding session based on the issue provider.
 // The optional body parameter contains the issue description/body text.
 func FormatInitialMessage(ref config.IssueRef, body string) string {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -650,6 +650,9 @@ func (w *SessionWorker) handleGetReviewComments(req mcp.GetReviewCommentsRequest
 		return
 	}
 
+	// Filter out our own transcript comments — they aren't review feedback.
+	comments = FilterTranscriptComments(comments)
+
 	mcpComments := make([]mcp.ReviewComment, len(comments))
 	for i, c := range comments {
 		mcpComments[i] = mcp.ReviewComment{


### PR DESCRIPTION
## Summary
Prevents the daemon from treating its own session transcript comments as review feedback, which could cause unnecessary re-processing of already-addressed comments.

## Changes
- Add `FilterTranscriptComments` helper that strips out PR comments containing the `<summary>Session Transcript</summary>` marker
- Apply the filter in `addressFeedback` after updating the comment count (so counts stay in sync with `GetBatchPRStatesWithComments`) but before formatting the prompt
- Apply the same filter in `handleGetReviewComments` so MCP-served review comments also exclude transcripts
- Add comprehensive tests for the new filter (transcript removal, no-op when none present, all-transcripts case, nil/empty input, partial string match)

## Test plan
- `go test -p=1 -count=1 ./internal/worker/...` — validates `FilterTranscriptComments` behavior
- `go test -p=1 -count=1 ./...` — full suite passes
- Manual: trigger a review cycle on a PR that has a session transcript comment; verify the transcript is not included in the feedback prompt sent to Claude

Fixes #29