### PR TITLE
feat(workflow): add git.format action for auto-formatting

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -691,6 +691,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("github.close_issue", &closeIssueAction{daemon: d})
 	registry.Register("github.request_review", &requestReviewAction{daemon: d})
 	registry.Register("ai.fix_ci", &fixCIAction{daemon: d})
+	registry.Register("git.format", &formatAction{daemon: d})
 	return registry
 }
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -138,7 +138,8 @@ var ValidActions = map[string]bool{
 	"github.remove_label":   true,
 	"github.close_issue":    true,
 	"github.request_review": true,
-	"ai.fix_ci":            true,
+	"ai.fix_ci":             true,
+	"git.format":            true,
 }
 
 // ValidEvents is the set of recognized event names for wait states.

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -123,6 +123,11 @@ func validateState(name string, state *State, allStates map[string]*State) []Val
 			errs = append(errs, validateRequestReviewParams(prefix, state.Params)...)
 		}
 
+		// Validate params for git.format action
+		if state.Action == "git.format" {
+			errs = append(errs, validateFormatParams(prefix, state.Params)...)
+		}
+
 	case StateTypeWait:
 		// Wait states require event
 		if state.Event == "" {
@@ -416,6 +421,37 @@ func validateRequestReviewParams(prefix string, params map[string]any) []Validat
 		errs = append(errs, ValidationError{
 			Field:   prefix + ".params.reviewer",
 			Message: "reviewer must not be empty",
+		})
+	}
+
+	return errs
+}
+
+// validateFormatParams validates params for git.format actions.
+func validateFormatParams(prefix string, params map[string]any) []ValidationError {
+	var errs []ValidationError
+
+	if params == nil {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".params.command",
+			Message: "command is required for git.format action",
+		})
+		return errs
+	}
+
+	command, ok := params["command"]
+	if !ok || command == nil {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".params.command",
+			Message: "command is required for git.format action",
+		})
+		return errs
+	}
+
+	if s, ok := command.(string); ok && s == "" {
+		errs = append(errs, ValidationError{
+			Field:   prefix + ".params.command",
+			Message: "command must not be empty",
 		})
 	}
 

--- a/internal/workflow/validate_test.go
+++ b/internal/workflow/validate_test.go
@@ -665,6 +665,54 @@ func TestValidate(t *testing.T) {
 			wantFields: nil,
 		},
 		{
+			name: "git.format missing command param",
+			cfg: &Config{
+				Start:  "fmt",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"fmt":  {Type: StateTypeTask, Action: "git.format", Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.fmt.params.command"},
+		},
+		{
+			name: "git.format with empty command param",
+			cfg: &Config{
+				Start:  "fmt",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"fmt":  {Type: StateTypeTask, Action: "git.format", Next: "done", Params: map[string]any{"command": ""}},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.fmt.params.command"},
+		},
+		{
+			name: "git.format with valid command",
+			cfg: &Config{
+				Start:  "fmt",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"fmt":  {Type: StateTypeTask, Action: "git.format", Next: "done", Params: map[string]any{"command": "go fmt ./..."}},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: nil,
+		},
+		{
+			name: "git.format with command and custom message",
+			cfg: &Config{
+				Start:  "fmt",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"fmt":  {Type: StateTypeTask, Action: "git.format", Next: "done", Params: map[string]any{"command": "prettier --write .", "message": "chore: format"}},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: nil,
+		},
+		{
 			name: "cycle detection: simple A→B→A",
 			cfg: &Config{
 				Start:  "a",


### PR DESCRIPTION
## Summary
Adds a new `git.format` workflow action that runs a formatter command in the session's worktree and commits any resulting changes. This enables workflows to automatically apply code formatting (e.g., `go fmt`, `prettier`) as a discrete step.

## Changes
- Add `formatAction` struct and `runFormatter` method in `internal/daemon/actions.go` that executes a shell command, stages changes, and commits with a configurable message
- Register `git.format` in the action registry (`internal/daemon/daemon.go`)
- Add `git.format` to `ValidActions` in `internal/workflow/config.go`
- Add `validateFormatParams` in `internal/workflow/validate.go` to require a non-empty `command` parameter
- Add comprehensive tests for the action (work item not found, session not found, missing/empty command, no changes, with changes, custom commit message, command failure, RepoPath fallback)
- Add validation tests for `git.format` params in `internal/workflow/validate_test.go`

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify action execution tests
- Run `go test -p=1 -count=1 ./internal/workflow/...` to verify validation tests
- Configure a workflow with a `git.format` step (e.g., `command: "go fmt ./..."`) and verify it formats and commits changes

Fixes #32