### PR TITLE
fix: intelligent recovery for addressing_feedback/pushing phases

### DIFF
--- a/internal/daemon/recovery.go
+++ b/internal/daemon/recovery.go
@@ -29,31 +29,9 @@ func (d *Daemon) recoverFromState(ctx context.Context) {
 			// Worker was running but daemon restarted — no worker exists
 			d.recoverAsyncPending(ctx, item, log)
 
-		case "addressing_feedback":
-			// Was addressing feedback — reset to idle for re-polling.
-			// Re-stamp StepEnteredAt so timeout enforcement works after recovery.
-			log.Info("was addressing feedback, resetting to idle")
-			d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
-				now := time.Now()
-				it.Phase = "idle"
-				if it.StepEnteredAt.IsZero() {
-					it.StepEnteredAt = now
-				}
-				it.UpdatedAt = now
-			})
-
-		case "pushing":
-			// Was pushing — reset to idle for re-polling.
-			// Re-stamp StepEnteredAt so timeout enforcement works after recovery.
-			log.Info("was pushing, resetting to idle")
-			d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
-				now := time.Now()
-				it.Phase = "idle"
-				if it.StepEnteredAt.IsZero() {
-					it.StepEnteredAt = now
-				}
-				it.UpdatedAt = now
-			})
+		case "addressing_feedback", "pushing":
+			// Worker or push was in-flight — check actual PR state to decide next step
+			d.recoverWaitPhase(ctx, item, log)
 
 		case "retry_pending":
 			// Was waiting to retry — reset to idle so it retries on next tick
@@ -69,6 +47,83 @@ func (d *Daemon) recoverFromState(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// recoverWaitPhase handles recovery for items that were in addressing_feedback or pushing
+// phase when the daemon stopped. Instead of blindly resetting to idle, it checks the
+// actual PR state on GitHub to determine the correct recovery action.
+func (d *Daemon) recoverWaitPhase(ctx context.Context, item *daemonstate.WorkItem, log interface{ Info(string, ...any) }) {
+	sess := d.config.GetSession(item.SessionID)
+	if sess == nil {
+		log.Info("session not found, resetting to idle", "phase", item.Phase)
+		d.resetPhaseToIdle(item)
+		return
+	}
+
+	if item.Branch == "" {
+		log.Info("no branch, resetting to idle", "phase", item.Phase)
+		d.resetPhaseToIdle(item)
+		return
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	prState, err := d.gitService.GetPRState(pollCtx, sess.RepoPath, item.Branch)
+	if err != nil {
+		log.Info("could not check PR state, resetting to idle", "phase", item.Phase, "error", err)
+		d.resetPhaseToIdle(item)
+		return
+	}
+
+	if prState == git.PRStateMerged {
+		log.Info("PR already merged, marking completed")
+		d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
+			it.CurrentStep = "done"
+			it.Phase = "idle"
+			it.State = daemonstate.WorkItemCompleted
+			now := time.Now()
+			it.CompletedAt = &now
+			it.UpdatedAt = now
+		})
+		return
+	}
+
+	if prState == git.PRStateClosed {
+		log.Info("PR was closed, marking failed")
+		d.state.SetErrorMessage(item.ID, "PR was closed while daemon was offline")
+		d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
+			it.Phase = "idle"
+			it.UpdatedAt = time.Now()
+		})
+		d.state.MarkWorkItemTerminal(item.ID, false)
+		return
+	}
+
+	// PR is open — check if it's already approved (only relevant at await_review)
+	if item.CurrentStep == "await_review" {
+		reviewDecision, err := d.gitService.CheckPRReviewDecision(pollCtx, sess.RepoPath, item.Branch)
+		if err == nil && reviewDecision == git.ReviewApproved {
+			log.Info("PR approved, advancing to merge")
+			d.state.AdvanceWorkItem(item.ID, "merge", "idle")
+			return
+		}
+	}
+
+	log.Info("PR open, resetting to idle for continued polling", "phase", item.Phase)
+	d.resetPhaseToIdle(item)
+}
+
+// resetPhaseToIdle resets a work item's phase to idle while preserving its current step.
+func (d *Daemon) resetPhaseToIdle(item *daemonstate.WorkItem) {
+	d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
+		now := time.Now()
+		it.Phase = "idle"
+		if it.StepEnteredAt.IsZero() {
+			it.StepEnteredAt = now
+		}
+		it.UpdatedAt = now
+	})
 }
 
 // recoverAsyncPending handles recovery when a worker was active but daemon restarted.


### PR DESCRIPTION
## Summary
- Replaces blind reset-to-idle recovery for `addressing_feedback` and `pushing` phases with PR state checks on GitHub
- On daemon restart, checks actual PR state: marks completed if merged, marks failed if closed, advances to merge if approved, or falls back to idle for continued polling
- Extracts `resetPhaseToIdle` helper to deduplicate idle-reset logic

## Test plan
- [x] Tests pass for all recovery paths: PR merged, PR closed, PR approved, PR open not approved
- [x] Tests pass for edge cases: no session, no branch, API error fallback
- [x] Full test suite passes (`go test -p=1 -count=1 ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)