### PR TITLE
fix: include "fix" in on_failure validation error message

### DIFF
--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -473,7 +473,7 @@ func validateCIParams(prefix string, params map[string]any) []ValidationError {
 			default:
 				errs = append(errs, ValidationError{
 					Field:   prefix + ".params.on_failure",
-					Message: fmt.Sprintf("unknown on_failure policy %q (must be abandon, retry, or notify)", s),
+					Message: fmt.Sprintf("unknown on_failure policy %q (must be abandon, retry, notify, or fix)", s),
 				})
 			}
 		}


### PR DESCRIPTION
## Summary
Corrects the validation error message for the `on_failure` parameter in CI params to include "fix" as a valid policy option.

## Changes
- Updated the error message in `validateCIParams` to list "fix" as a valid `on_failure` policy alongside abandon, retry, and notify

## Test plan
- Run `go test -p=1 -count=1 ./internal/workflow/...` to verify validation tests pass

Fixes #37