### PR TITLE
fix(worker): derive timeout contexts from w.ctx in worker handlers

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -568,7 +568,7 @@ func (w *SessionWorker) handleMergeChild(req mcp.MergeChildRequest) {
 
 	log.Info("merging child to parent", "childID", childSess.ID, "childBranch", childSess.Branch)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(w.ctx, 2*time.Minute)
 	defer cancel()
 
 	resultCh := w.host.GitService().MergeToParent(ctx, childSess.WorkTree, childSess.Branch, sess.WorkTree, sess.Branch, "")
@@ -638,7 +638,7 @@ func (w *SessionWorker) handleGetReviewComments(req mcp.GetReviewCommentsRequest
 
 	log.Info("fetching review comments via MCP tool", "branch", sess.Branch)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(w.ctx, 30*time.Second)
 	defer cancel()
 
 	comments, err := w.host.GitService().FetchPRReviewComments(ctx, sess.RepoPath, sess.Branch)


### PR DESCRIPTION
## Summary
Fix worker handler methods to derive timeout contexts from the worker's context (`w.ctx`) instead of `context.Background()`, ensuring proper cancellation propagation during shutdown.

## Changes
- Change `handleMergeChild` to use `w.ctx` as parent context for its 2-minute timeout
- Change `handleGetReviewComments` to use `w.ctx` as parent context for its 30-second timeout

## Test plan
- Run `go test -p=1 -count=1 ./internal/worker/...`
- Verify that when a worker is shut down (context cancelled), in-flight merge and review comment operations are properly cancelled rather than running to completion against `context.Background()`

Fixes #40