### PR TITLE
fix: read from realPath to close TOCTOU window in ResolveSystemPrompt

### DIFF
--- a/internal/workflow/prompt.go
+++ b/internal/workflow/prompt.go
@@ -49,7 +49,7 @@ func ResolveSystemPrompt(prompt, repoPath string) (string, error) {
 		return "", fmt.Errorf("prompt file %q escapes repository root", relPath)
 	}
 
-	data, err := os.ReadFile(absPath)
+	data, err := os.ReadFile(realPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read prompt file %q: %w", relPath, err)
 	}


### PR DESCRIPTION
## Summary
Fixes a time-of-check-time-of-use (TOCTOU) vulnerability in `ResolveSystemPrompt` where the symlink target was validated via `realPath` but the file was read from the original `absPath`.

## Changes
- Read from `realPath` instead of `absPath` in `ResolveSystemPrompt` so the validated path is the same path that gets read
- Add regression test for internal symlinks confirming the resolved content is returned correctly

## Test plan
- `go test -p=1 -count=1 ./internal/workflow/...` — new `TestResolveSystemPrompt_SymlinkInternal` verifies the fix

Fixes #36