### PR TITLE
fix: pause new work after repeated config save failures

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -42,6 +42,7 @@ type Daemon struct {
 
 	// Config save tracking
 	configSaveFailures int
+	configSavePaused   bool // true after 5+ consecutive failures; blocks new work
 
 	// Options
 	once                  bool


### PR DESCRIPTION
## Summary
Prevents the daemon from accepting or starting new work when config saves have failed repeatedly, avoiding silent state drift that could lead to duplicate sessions or lost progress.

## Changes
- Add `configSavePaused` flag to Daemon, set after 5+ consecutive config save failures
- Block `pollForNewIssues` and `startQueuedItems` when paused, with warning logs
- Automatically resume when a config save succeeds (recovery path)
- Upgrade log message at threshold to clarify that new work is paused

## Test plan
- `TestDaemon_SaveConfig_PausesAfterThreshold` — verifies flag is set after 5 consecutive failures
- `TestDaemon_SaveConfig_RecoveryResumesPaused` — verifies flag clears and counter resets on successful save
- `TestDaemon_PollForNewIssues_SkipsWhenPaused` — verifies no new issues are fetched while paused
- `TestDaemon_StartQueuedItems_SkipsWhenPaused` — verifies queued items are not promoted while paused
- Run `go test -p=1 -count=1 ./...` to validate all tests pass

Fixes #53