### PR TITLE
fix(workflow): remove note blocks from mermaid diagram output

### DIFF
--- a/internal/workflow/visualize.go
+++ b/internal/workflow/visualize.go
@@ -70,11 +70,6 @@ func GenerateMermaid(cfg *Config) string {
 			}
 		}
 
-		// Add note for params
-		note := formatStateNote(state)
-		if note != "" {
-			sb.WriteString(fmt.Sprintf("    note right of %s\n        %s\n    end note\n", name, note))
-		}
 	}
 
 	return sb.String()
@@ -97,15 +92,3 @@ func formatChoiceLabel(rule ChoiceRule) string {
 	return rule.Variable
 }
 
-// formatStateNote creates a note string from a state's params.
-func formatStateNote(state *State) string {
-	if len(state.Params) == 0 {
-		return ""
-	}
-
-	var parts []string
-	for k, v := range state.Params {
-		parts = append(parts, fmt.Sprintf("%s: %v", k, v))
-	}
-	return strings.Join(parts, ", ")
-}


### PR DESCRIPTION
## Summary
Removes note blocks (state parameter annotations) from the workflow Mermaid diagram output, simplifying the generated diagrams.

## Changes
- Remove note block generation from `GenerateMermaid` in `internal/workflow/visualize.go`
- Remove the unused `formatStateNote` helper function

## Test plan
- Run `go test -p=1 -count=1 ./internal/workflow/...` to verify existing tests pass
- Generate a Mermaid diagram from a workflow config and confirm note blocks no longer appear

Fixes #62