### PR TITLE
fix(docs): update documentation URL to zhubert.com/erg

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or [build from source](#build-from-source).
 erg --repo owner/repo
 ```
 
-Label a GitHub issue `queued` and erg picks it up automatically. For Asana or Linear, configure the [workflow source](https://zhubert.github.io/erg/).
+Label a GitHub issue `queued` and erg picks it up automatically. For Asana or Linear, configure the [workflow source](https://zhubert.com/erg/).
 
 ## How It Works
 
@@ -40,7 +40,7 @@ For complex issues, Claude can delegate subtasks to child sessions via MCP tools
 
 ## Documentation
 
-Full documentation — workflow configuration, state types, error handling, hooks, CLI reference — is at **[zhubert.github.io/erg](https://zhubert.github.io/erg/)**.
+Full documentation — workflow configuration, state types, error handling, hooks, CLI reference — is at **[zhubert.com/erg](https://zhubert.com/erg/)**.
 
 ## Build from Source
 


### PR DESCRIPTION
## Summary
Updates the documentation URL in the README from `zhubert.github.io/erg` to `zhubert.com/erg`.

## Changes
- Updated workflow source link from `zhubert.github.io/erg` to `zhubert.com/erg`
- Updated documentation section link and display text to use the new domain

## Test plan
- Verify the links in the README render correctly and point to the new URL
- Confirm `https://zhubert.com/erg/` resolves properly

Fixes #65