### PR TITLE
docs: replace two-liner brew install with one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Erg polls for work from GitHub, Asana, or Linear, spins up containerized Claude 
 ## Install
 
 ```bash
-brew tap zhubert/tap
-brew install erg
+brew install zhubert/tap/erg
 ```
 
 Or [build from source](#build-from-source).

--- a/docs/index.html
+++ b/docs/index.html
@@ -960,8 +960,8 @@
         <h3>Homebrew</h3>
         <div class="install-block">
             <span class="prompt-char">$</span>
-            <code>brew tap zhubert/tap && brew install erg</code>
-            <button class="copy-btn" onclick="copyCmd(this,'brew tap zhubert/tap && brew install erg')">copy</button>
+            <code>brew install zhubert/tap/erg</code>
+            <button class="copy-btn" onclick="copyCmd(this,'brew install zhubert/tap/erg')">copy</button>
         </div>
 
         <h3>Build from source</h3>


### PR DESCRIPTION
## Summary
Simplifies the Homebrew installation instructions by combining the tap and install into a single command.

## Changes
- Replace `brew tap zhubert/tap && brew install erg` with `brew install zhubert/tap/erg` in README.md
- Update the same install command in the docs site (docs/index.html)

## Test plan
- Verify the one-liner `brew install zhubert/tap/erg` works correctly
- Check that the docs site copy button copies the updated command

Fixes #66