### PR TITLE
docs: add full action and wait event reference to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -804,6 +804,124 @@
         }
       }
 
+      /* ---- Action reference ---- */
+
+      .action-ref {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1.25rem 1.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .action-header {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .action-title {
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--accent);
+      }
+
+      .action-desc {
+        font-size: 0.88rem;
+        color: var(--text-muted);
+        margin-bottom: 0.75rem;
+        line-height: 1.6;
+      }
+
+      .badge {
+        display: inline-block;
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 0.63rem;
+        font-weight: 500;
+        padding: 0.15rem 0.5rem;
+        border-radius: 100px;
+        flex-shrink: 0;
+      }
+
+      .badge-async {
+        background: rgba(167, 139, 250, 0.1);
+        border: 1px solid rgba(167, 139, 250, 0.25);
+        color: var(--violet);
+      }
+
+      .badge-sync {
+        background: rgba(52, 211, 153, 0.1);
+        border: 1px solid rgba(52, 211, 153, 0.25);
+        color: var(--green);
+      }
+
+      .param-section {
+        margin-top: 0.85rem;
+      }
+
+      .param-section-title {
+        font-size: 0.68rem;
+        font-weight: 600;
+        color: var(--text-dim);
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        margin-bottom: 0.4rem;
+      }
+
+      .param-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.82rem;
+        border-radius: 6px;
+        overflow: hidden;
+        border: 1px solid var(--border);
+      }
+
+      .param-table th {
+        text-align: left;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.66rem;
+        font-weight: 600;
+        color: var(--text-dim);
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        background: var(--bg-inset);
+        border-bottom: 1px solid var(--border-light);
+      }
+
+      .param-table td {
+        padding: 0.45rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-muted);
+        vertical-align: top;
+      }
+
+      .param-table td:first-child {
+        font-family: "IBM Plex Mono", monospace;
+        color: var(--cyan);
+        font-size: 0.8rem;
+        white-space: nowrap;
+      }
+
+      .param-table td:nth-child(2) {
+        font-family: "IBM Plex Mono", monospace;
+        color: var(--text-dim);
+        font-size: 0.78rem;
+        white-space: nowrap;
+      }
+
+      .param-table tr:last-child td {
+        border-bottom: none;
+      }
+
+      .param-none {
+        font-size: 0.82rem;
+        color: var(--text-dim);
+        margin-top: 0.35rem;
+      }
+
       @media (max-width: 480px) {
         .main h1 {
           font-size: 1.6rem;
@@ -877,6 +995,8 @@
           <li class="sidebar-section">
             <span class="sidebar-section-title">Reference</span>
             <a href="#cli" class="sidebar-link">CLI commands</a>
+            <a href="#actions" class="sidebar-link">Actions</a>
+            <a href="#events" class="sidebar-link">Wait events</a>
           </li>
         </ul>
         <div class="sidebar-footer">
@@ -2288,6 +2408,782 @@ stateDiagram-v2
             </tr>
           </tbody>
         </table>
+
+        <!-- Action reference -->
+        <h2 id="actions">Action reference</h2>
+        <p>
+          Actions are used in <code>task</code> states via the
+          <code>action:</code> key. Each action accepts typed
+          <code>params</code> and may produce output data that downstream
+          <code>choice</code> states can inspect.
+        </p>
+
+        <h3>AI actions</h3>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">ai.code</span>
+            <span class="badge badge-async">async</span>
+          </div>
+          <p class="action-desc">
+            Starts an autonomous Claude Code session that reads the issue,
+            writes code, runs tests, and commits changes locally. The daemon
+            waits for the session to complete before advancing.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>max_turns</td>
+                  <td>int</td>
+                  <td>50</td>
+                  <td>Maximum number of Claude turns per session.</td>
+                </tr>
+                <tr>
+                  <td>max_duration</td>
+                  <td>duration</td>
+                  <td>30m</td>
+                  <td>
+                    Hard time limit for the session, e.g. <code>20m</code>,
+                    <code>2h</code>.
+                  </td>
+                </tr>
+                <tr>
+                  <td>containerized</td>
+                  <td>bool</td>
+                  <td>true</td>
+                  <td>Run Claude inside a Docker container sandbox.</td>
+                </tr>
+                <tr>
+                  <td>supervisor</td>
+                  <td>bool</td>
+                  <td>false</td>
+                  <td>
+                    Enable multi-session mode — Claude can spawn child sessions
+                    for parallel subtasks.
+                  </td>
+                </tr>
+                <tr>
+                  <td>system_prompt</td>
+                  <td>string</td>
+                  <td><em>built-in</em></td>
+                  <td>
+                    Inline prompt or <code>file:.erg/prompt.md</code> to load
+                    from the repo. Overrides the default coding prompt.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">
+              None. Session completion is signalled internally; the daemon
+              advances the state machine when the worker exits.
+            </p>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Notes</div>
+            <ul
+              style="
+                margin: 0.35rem 0 0;
+                padding-left: 1.25rem;
+                font-size: 0.82rem;
+                color: var(--text-muted);
+              "
+            >
+              <li>
+                If the branch already has an open PR, coding is skipped and
+                the workflow advances to <code>github.create_pr</code>, which
+                detects the existing PR.
+              </li>
+              <li>
+                If the branch was already merged, the issue is closed and the
+                workflow jumps to <code>done</code>.
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">ai.fix_ci</span>
+            <span class="badge badge-async">async</span>
+          </div>
+          <p class="action-desc">
+            Resumes the existing Claude session to fix failing CI. Fetches
+            failure logs from the most recent GitHub Actions run and passes
+            them to Claude as context.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>max_ci_fix_rounds</td>
+                  <td>int</td>
+                  <td>3</td>
+                  <td>
+                    Maximum number of CI fix attempts before returning an
+                    error.
+                  </td>
+                </tr>
+                <tr>
+                  <td>system_prompt</td>
+                  <td>string</td>
+                  <td><em>built-in</em></td>
+                  <td>Custom system prompt for the fix session.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ci_fix_rounds</td>
+                  <td>int</td>
+                  <td>
+                    Incremented on each attempt. Inspect in
+                    <code>choice</code> states to check round count.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <h3>GitHub actions</h3>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.create_pr</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Opens a pull request from the working branch to the base branch.
+            Detects and reuses an existing PR if one was already opened in a
+            previous attempt.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>link_issue</td>
+                  <td>bool</td>
+                  <td>true</td>
+                  <td>
+                    Add a closing reference to the source issue in the PR body
+                    (e.g. <code>Closes #42</code>).
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>pr_url</td>
+                  <td>string</td>
+                  <td>URL of the created (or existing) pull request.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Notes</div>
+            <ul
+              style="
+                margin: 0.35rem 0 0;
+                padding-left: 1.25rem;
+                font-size: 0.82rem;
+                color: var(--text-muted);
+              "
+            >
+              <li>
+                If the coding session made no commits, the issue is closed
+                automatically and the workflow skips to <code>done</code>.
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.push</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Pushes committed changes to the remote branch. Typically used
+            after Claude addresses review feedback.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <p class="param-none">None.</p>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.merge</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Merges the pull request into the base branch using the configured
+            strategy.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>method</td>
+                  <td>string</td>
+                  <td>rebase</td>
+                  <td>
+                    Merge strategy: <code>rebase</code>, <code>squash</code>,
+                    or <code>merge</code>.
+                  </td>
+                </tr>
+                <tr>
+                  <td>cleanup</td>
+                  <td>bool</td>
+                  <td>false</td>
+                  <td>
+                    Delete the worktree and branch after a successful merge.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.comment_issue</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Posts a comment on the original issue associated with the work
+            item.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>body</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>
+                    Comment text. Prefix with <code>file:</code> to load
+                    content from a repo path, e.g.
+                    <code>file:.erg/comments/msg.md</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.comment_pr</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Posts a comment on the pull request for the work item.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>body</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>
+                    Comment text. Prefix with <code>file:</code> to load
+                    content from a repo path, e.g.
+                    <code>file:.erg/comments/msg.md</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.add_label</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">Adds a label to the source issue.</p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>label</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>Label name to add.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.remove_label</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">Removes a label from the source issue.</p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>label</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>Label name to remove.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.close_issue</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">Closes the source issue.</p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <p class="param-none">None.</p>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">github.request_review</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Requests a review from a specific GitHub user on the pull request.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>reviewer</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>GitHub username to request a review from.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <h3>Git actions</h3>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">git.format</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Runs a formatter command in the session worktree, stages all
+            changes with <code>git add -A</code>, and commits them. Silently
+            succeeds if the formatter produces no changes.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>command</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>
+                    Shell command to run, e.g. <code>gofmt -w .</code> or
+                    <code>prettier --write .</code>.
+                  </td>
+                </tr>
+                <tr>
+                  <td>message</td>
+                  <td>string</td>
+                  <td>Apply auto-formatting</td>
+                  <td>
+                    Commit message used when the formatter produces changes.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <!-- Wait events reference -->
+        <h2 id="events">Wait events</h2>
+        <p>
+          Events are used in <code>wait</code> states via the
+          <code>event:</code> key. The daemon polls on each tick and advances
+          the state machine when the event fires. All wait states support
+          <code>timeout</code> and <code>timeout_next</code>.
+        </p>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">pr.reviewed</span>
+          </div>
+          <p class="action-desc">
+            Fires when the pull request receives a formal approval. While
+            waiting, the daemon automatically resumes Claude to address new
+            review comments (configurable via <code>auto_address</code>).
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>auto_address</td>
+                  <td>bool</td>
+                  <td>true</td>
+                  <td>
+                    Automatically resume Claude to address new review comments
+                    while waiting for approval.
+                  </td>
+                </tr>
+                <tr>
+                  <td>max_feedback_rounds</td>
+                  <td>int</td>
+                  <td>3</td>
+                  <td>
+                    Maximum number of feedback rounds before
+                    auto-addressing stops.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>review_approved</td>
+                  <td>bool</td>
+                  <td>Set to <code>true</code> when a reviewer approves.</td>
+                </tr>
+                <tr>
+                  <td>pr_merged_externally</td>
+                  <td>bool</td>
+                  <td>
+                    Set to <code>true</code> if the PR was merged outside the
+                    daemon.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">ci.complete</span>
+          </div>
+          <p class="action-desc">
+            Fires when all CI checks on the PR pass. Configurable behaviour
+            on CI failure lets workflows route to <code>ai.fix_ci</code> or
+            other states.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>on_failure</td>
+                  <td>string</td>
+                  <td>retry</td>
+                  <td>
+                    Action when CI fails: <code>retry</code> — keep waiting
+                    (default); <code>fix</code> — fire the event so the
+                    workflow can route to <code>ai.fix_ci</code>;
+                    <code>abandon</code> or <code>notify</code> — emit data
+                    for downstream routing without advancing.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ci_passed</td>
+                  <td>bool</td>
+                  <td>True when all checks pass.</td>
+                </tr>
+                <tr>
+                  <td>ci_failed</td>
+                  <td>bool</td>
+                  <td>True when any check fails.</td>
+                </tr>
+                <tr>
+                  <td>ci_action</td>
+                  <td>string</td>
+                  <td>
+                    The <code>on_failure</code> strategy that was applied.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">pr.mergeable</span>
+          </div>
+          <p class="action-desc">
+            Convenience event that combines <code>pr.reviewed</code> and
+            <code>ci.complete</code>. Fires only when both review approval
+            and CI pass simultaneously. Useful for minimal pipelines that
+            don't need separate wait states.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>require_review</td>
+                  <td>bool</td>
+                  <td>true</td>
+                  <td>Require an approved review before firing.</td>
+                </tr>
+                <tr>
+                  <td>require_ci</td>
+                  <td>bool</td>
+                  <td>true</td>
+                  <td>Require CI to pass before firing.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>review_approved</td>
+                  <td>bool</td>
+                  <td>True when a reviewer has approved.</td>
+                </tr>
+                <tr>
+                  <td>ci_passed</td>
+                  <td>bool</td>
+                  <td>True when all CI checks pass.</td>
+                </tr>
+                <tr>
+                  <td>ci_failed</td>
+                  <td>bool</td>
+                  <td>True when any CI check fails.</td>
+                </tr>
+                <tr>
+                  <td>pr_merged_externally</td>
+                  <td>bool</td>
+                  <td>True if the PR was merged outside the daemon.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
 
         <!-- Installation -->
         <h2 id="install">Installation</h2>


### PR DESCRIPTION
## Summary
Adds comprehensive reference documentation for all workflow actions and wait events to the docs site, giving users a complete API reference for building custom workflows.

## Changes
- Added "Actions" and "Wait events" sections to the sidebar navigation
- Documented all AI actions (`ai.code`, `ai.fix_ci`) with params, output data, and notes
- Documented all GitHub actions (`github.create_pr`, `github.push`, `github.merge`, `github.comment_issue`, `github.comment_pr`, `github.add_label`, `github.remove_label`, `github.close_issue`, `github.request_review`)
- Documented git actions (`git.format`)
- Documented all wait events (`pr.reviewed`, `ci.complete`, `pr.mergeable`) with params and output data
- Added supporting CSS styles for the action reference cards, badges (async/sync), and parameter tables

## Test plan
- Open `docs/index.html` in a browser and verify the new "Actions" and "Wait events" sidebar links navigate to the correct sections
- Verify action reference cards render correctly with proper styling
- Check that async/sync badges display with correct colors
- Verify parameter tables are readable and properly formatted
- Test responsive layout on mobile viewports

Fixes #75