### PR TITLE
docs: move Installation section to Getting Started flow

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1128,6 +1128,46 @@
           </li>
         </ol>
 
+        <!-- Installation -->
+        <h2 id="install">Installation</h2>
+        <h3>Homebrew</h3>
+        <div class="install-block">
+          <span class="prompt-char">$</span>
+          <code>brew install zhubert/tap/erg</code>
+          <button
+            class="copy-btn"
+            onclick="copyCmd(this, 'brew install zhubert/tap/erg')"
+          >
+            copy
+          </button>
+        </div>
+
+        <h3>Build from source</h3>
+        <div class="install-block">
+          <span class="prompt-char">$</span>
+          <code>go build -o erg .</code>
+          <button class="copy-btn" onclick="copyCmd(this, 'go build -o erg .')">
+            copy
+          </button>
+        </div>
+
+        <h3>Quick start</h3>
+        <p>After installation, start the daemon pointed at your repo:</p>
+        <div class="install-block">
+          <span class="prompt-char">$</span>
+          <code>erg --repo owner/repo</code>
+          <button
+            class="copy-btn"
+            onclick="copyCmd(this, 'erg --repo owner/repo')"
+          >
+            copy
+          </button>
+        </div>
+        <p>
+          Label a GitHub issue with <code>queued</code> and the agent will pick
+          it up on the next poll cycle.
+        </p>
+
         <!-- Workflow configuration -->
         <h2 id="workflow">Workflow configuration</h2>
         <p>
@@ -3184,46 +3224,6 @@ stateDiagram-v2
             </table>
           </div>
         </div>
-
-        <!-- Installation -->
-        <h2 id="install">Installation</h2>
-        <h3>Homebrew</h3>
-        <div class="install-block">
-          <span class="prompt-char">$</span>
-          <code>brew install zhubert/tap/erg</code>
-          <button
-            class="copy-btn"
-            onclick="copyCmd(this, 'brew install zhubert/tap/erg')"
-          >
-            copy
-          </button>
-        </div>
-
-        <h3>Build from source</h3>
-        <div class="install-block">
-          <span class="prompt-char">$</span>
-          <code>go build -o erg .</code>
-          <button class="copy-btn" onclick="copyCmd(this, 'go build -o erg .')">
-            copy
-          </button>
-        </div>
-
-        <h3>Quick start</h3>
-        <p>After installation, start the daemon pointed at your repo:</p>
-        <div class="install-block">
-          <span class="prompt-char">$</span>
-          <code>erg --repo owner/repo</code>
-          <button
-            class="copy-btn"
-            onclick="copyCmd(this, 'erg --repo owner/repo')"
-          >
-            copy
-          </button>
-        </div>
-        <p>
-          Label a GitHub issue with <code>queued</code> and the agent will pick
-          it up on the next poll cycle.
-        </p>
 
         <div
           style="


### PR DESCRIPTION
## Summary
Repositions the Installation section earlier in the docs page so it appears within the Getting Started flow, making it easier for new users to find setup instructions.

## Changes
- Moved the Installation block (Homebrew, Build from source, Quick start) from near the bottom of the page to right after the Getting Started steps
- No content changes — purely a reorder

## Test plan
- Open `docs/index.html` in a browser and verify the Installation section appears immediately after the Getting Started steps
- Confirm the anchor link `#install` still navigates correctly
- Verify copy buttons still function for all install commands

Fixes #79