### PR TITLE
feat: add proper daemon fork/detach with foreground mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,10 @@ go test -p=1 -count=1 ./...     # Test (use -p=1 in containers to avoid Go toolc
 ./erg --debug           # Enable debug logging (on by default)
 ./erg -q                # Quiet mode (info level only)
 
-./erg --repo owner/repo         # Run headless daemon
-./erg --repo owner/repo --once  # Process one tick and exit
+./erg --repo owner/repo         # Fork/detach daemon (prints PID, exits)
+./erg -f --repo owner/repo     # Foreground with live status display
+./erg --repo owner/repo --once  # Process one tick and exit (implies -f)
+./erg status                    # One-shot daemon status summary
 ./erg clean                     # Clear daemon state and lock files
 ./erg clean -y                  # Clear without confirmation prompt
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Or [build from source](#build-from-source).
 erg --repo owner/repo
 ```
 
-Label a GitHub issue `queued` and erg picks it up automatically. For Asana or Linear, configure the [workflow source](https://zhubert.com/erg/).
+This forks into the background, prints the PID and log path, and exits. Label a GitHub issue `queued` and erg picks it up automatically.
+
+```bash
+erg -f --repo owner/repo   # Stay in foreground with live status display
+erg status                  # One-shot daemon status summary
+```
+
+For Asana or Linear, configure the [workflow source](https://zhubert.com/erg/).
 
 ## How It Works
 

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/zhubert/erg/internal/agentconfig"
 	"github.com/zhubert/erg/internal/container"
 	"github.com/zhubert/erg/internal/daemon"
+	"github.com/zhubert/erg/internal/daemonstate"
 	"github.com/zhubert/erg/internal/workflow"
 	"github.com/zhubert/erg/internal/cli"
 	"github.com/zhubert/erg/internal/git"
@@ -21,60 +24,174 @@ import (
 )
 
 var (
-	agentOnce bool
-	agentRepo string
+	agentOnce       bool
+	agentRepo       string
+	agentForeground bool
+	agentDaemonMode bool // hidden --_daemon flag for re-exec child
 )
+
+// osExecutable is the function used to resolve the current binary path.
+// Overridden in tests.
+var osExecutable = os.Executable
 
 func init() {
 	rootCmd.RunE = runAgent
 	rootCmd.Flags().BoolVar(&agentOnce, "once", false, "Run one tick and exit (vs continuous daemon)")
 	rootCmd.Flags().StringVar(&agentRepo, "repo", "", "Repo to poll (owner/repo or filesystem path)")
+	rootCmd.Flags().BoolVarP(&agentForeground, "foreground", "f", false, "Stay in foreground with live status display")
+	rootCmd.Flags().BoolVar(&agentDaemonMode, "_daemon", false, "Internal: run as detached daemon child")
+	rootCmd.Flags().MarkHidden("_daemon") //nolint:errcheck
 }
 
 func runAgent(cmd *cobra.Command, args []string) error {
+	// --once implies foreground
+	if agentOnce {
+		agentForeground = true
+	}
+
+	if agentDaemonMode {
+		return runDaemonChild(cmd, args)
+	}
+	if agentForeground {
+		return runForeground(cmd, args)
+	}
+	return daemonize(cmd, args)
+}
+
+// daemonize performs all setup visible to the user (prereqs, image build),
+// then re-execs itself with --_daemon to detach from the terminal.
+func daemonize(cmd *cobra.Command, args []string) error {
 	// Validate prerequisites
 	prereqs := cli.DefaultPrerequisites()
 	if err := cli.ValidateRequired(prereqs); err != nil {
 		return fmt.Errorf("%v\n\nInstall required tools and try again", err)
 	}
 
-	// Check that a container runtime is available (required for agent mode).
-	// Either docker or colima on PATH satisfies this requirement.
 	if !hasContainerRuntime() {
 		return fmt.Errorf("a container runtime is required for agent mode.\nInstall Docker: https://docs.docker.com/get-docker/\nInstall Colima: https://github.com/abiosoft/colima")
 	}
 
-	// Verify a container runtime daemon is actually running (not just binary present)
 	if err := checkDockerDaemon(); err != nil {
 		return err
 	}
 
-	// Enable debug logging for agent mode (always on for headless autonomous operation)
-	logger.SetDebug(true)
-
-	// Ensure logger is closed on exit
-	defer logger.Close()
-
-	// Create structured logger for agent output (always debug level)
-	agentLogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}))
-
 	// Create services
-	gitSvc := git.NewGitService()
 	sessSvc := session.NewSessionService()
 
-	// If --repo is not provided, try to detect from current working directory
+	// Resolve repo
 	resolved, err := resolveAgentRepo(context.Background(), agentRepo, sessSvc)
 	if err != nil {
 		return err
 	}
-	if resolved != agentRepo {
-		agentLogger.Info("no --repo specified, using current directory", "repo", resolved)
+	agentRepo = resolved
+
+	// Check no daemon already running for this repo
+	if pid, running := daemonstate.ReadLockStatus(agentRepo); running {
+		return fmt.Errorf("daemon already running for this repo (PID %d)", pid)
+	}
+
+	// Set up cancellable context for image build phase
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Temporary stdout logger for image build output the user should see
+	buildLogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	// Load workflow config + build image (visible to user)
+	wfCfg, err := workflow.LoadAndMerge(agentRepo)
+	if err != nil {
+		return fmt.Errorf("error loading workflow config: %w", err)
+	}
+
+	if wfCfg.Settings == nil || wfCfg.Settings.ContainerImage == "" {
+		detected := container.Detect(ctx, agentRepo)
+		buildLogger.Info("auto-detected languages", "languages", detected, "repo", agentRepo)
+
+		image, err := container.EnsureImage(ctx, detected, version, buildLogger)
+		if err != nil {
+			return fmt.Errorf("failed to auto-build container image: %w\n\n"+
+				"You can skip auto-detection by setting container_image in .erg/workflow.yaml", err)
+		}
+		_ = image // image cached; child will find it
+	}
+
+	// Build args for re-exec
+	childArgs := buildDaemonArgs(agentRepo, agentOnce)
+
+	// Re-exec self with --_daemon
+	self, err := osExecutable()
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+
+	child := exec.Command(self, childArgs...)
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	child.Stdin = nil
+	child.Stdout = nil
+	child.Stderr = nil
+
+	if err := child.Start(); err != nil {
+		return fmt.Errorf("failed to start daemon: %w", err)
+	}
+	childPID := child.Process.Pid
+
+	// Detach — we don't wait for the child
+	if err := child.Process.Release(); err != nil {
+		return fmt.Errorf("failed to detach daemon process: %w", err)
+	}
+
+	// Poll lock file to confirm child started (timeout 30s)
+	if err := waitForDaemonLock(agentRepo, childPID, 30*time.Second); err != nil {
+		return err
+	}
+
+	logPath, _ := logger.DefaultLogPath()
+	fmt.Printf("erg daemon started (PID %d)\nLogs: %s\n", childPID, logPath)
+	return nil
+}
+
+// waitForDaemonLock polls the lock file until the expected PID appears or timeout.
+func waitForDaemonLock(repo string, expectedPID int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pid, running := daemonstate.ReadLockStatus(repo)
+		if pid == expectedPID && running {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("daemon did not start within %s (expected PID %d)", timeout, expectedPID)
+}
+
+// buildDaemonArgs constructs the args slice for the re-exec'd child process.
+func buildDaemonArgs(repo string, once bool) []string {
+	args := []string{"--_daemon", "--repo", repo}
+	if once {
+		args = append(args, "--once")
+	}
+	return args
+}
+
+// runDaemonChild is the entry point for the detached daemon child.
+// All logging goes to file — no stdout.
+func runDaemonChild(_ *cobra.Command, _ []string) error {
+	// Enable debug logging for daemon mode
+	logger.SetDebug(true)
+	defer logger.Close()
+
+	fileLogger := logger.Get()
+
+	sessSvc := session.NewSessionService()
+
+	// Resolve repo (should already be set via --repo)
+	resolved, err := resolveAgentRepo(context.Background(), agentRepo, sessSvc)
+	if err != nil {
+		return err
 	}
 	agentRepo = resolved
 
-	// Set up signal handling (needed early for auto-detect/build cancellation)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -83,31 +200,141 @@ func runAgent(cmd *cobra.Command, args []string) error {
 
 	go func() {
 		sig := <-sigCh
-		agentLogger.Info("received signal, shutting down gracefully", "signal", sig)
+		fileLogger.Info("received signal, shutting down gracefully", "signal", sig)
 		cancel()
-		// On second signal, force exit
 		sig = <-sigCh
-		agentLogger.Warn("received second signal, force exiting", "signal", sig)
+		fileLogger.Warn("received second signal, force exiting", "signal", sig)
 		os.Exit(1)
 	}()
 
-	// Load workflow config for settings
+	return runDaemonWithLogger(ctx, fileLogger)
+}
+
+// runForeground runs the daemon in the current process with a live status display.
+func runForeground(_ *cobra.Command, _ []string) error {
+	// Validate prerequisites
+	prereqs := cli.DefaultPrerequisites()
+	if err := cli.ValidateRequired(prereqs); err != nil {
+		return fmt.Errorf("%v\n\nInstall required tools and try again", err)
+	}
+
+	if !hasContainerRuntime() {
+		return fmt.Errorf("a container runtime is required for agent mode.\nInstall Docker: https://docs.docker.com/get-docker/\nInstall Colima: https://github.com/abiosoft/colima")
+	}
+
+	if err := checkDockerDaemon(); err != nil {
+		return err
+	}
+
+	// Enable debug logging
+	logger.SetDebug(true)
+	defer logger.Close()
+
+	fileLogger := logger.Get()
+
+	// Temporary stdout logger for build output
+	buildLogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	sessSvc := session.NewSessionService()
+
+	resolved, err := resolveAgentRepo(context.Background(), agentRepo, sessSvc)
+	if err != nil {
+		return err
+	}
+	if resolved != agentRepo && agentRepo != "" {
+		buildLogger.Info("using repo", "repo", resolved)
+	}
+	agentRepo = resolved
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigCh
+		fileLogger.Info("received signal, shutting down gracefully", "signal", sig)
+		cancel()
+		sig = <-sigCh
+		fileLogger.Warn("received second signal, force exiting", "signal", sig)
+		os.Exit(1)
+	}()
+
+	// Load workflow config + build image
 	wfCfg, err := workflow.LoadAndMerge(agentRepo)
 	if err != nil {
 		return fmt.Errorf("error loading workflow config: %w", err)
 	}
 
-	// Auto-detect container image if not explicitly configured
 	if wfCfg.Settings == nil || wfCfg.Settings.ContainerImage == "" {
 		detected := container.Detect(ctx, agentRepo)
-		agentLogger.Info("auto-detected languages", "languages", detected, "repo", agentRepo)
+		buildLogger.Info("auto-detected languages", "languages", detected, "repo", agentRepo)
 
-		image, err := container.EnsureImage(ctx, detected, version, agentLogger)
+		image, err := container.EnsureImage(ctx, detected, version, buildLogger)
 		if err != nil {
 			return fmt.Errorf("failed to auto-build container image: %w\n\n"+
 				"You can skip auto-detection by setting container_image in .erg/workflow.yaml", err)
 		}
 
+		if wfCfg.Settings == nil {
+			wfCfg.Settings = &workflow.SettingsConfig{}
+		}
+		wfCfg.Settings.ContainerImage = image
+	}
+
+	// Run daemon in a goroutine
+	daemonErr := make(chan error, 1)
+	go func() {
+		daemonErr <- runDaemonWithLogger(ctx, fileLogger)
+	}()
+
+	if agentOnce {
+		// For --once mode, just wait for the daemon to finish
+		return <-daemonErr
+	}
+
+	// Auto-refreshing status display
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	// Initial display
+	clearScreen()
+	_ = displayDashboard(agentRepo)
+
+	for {
+		select {
+		case err := <-daemonErr:
+			return err
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			clearScreen()
+			_ = displayDashboard(agentRepo)
+		}
+	}
+}
+
+// runDaemonWithLogger creates all services and runs the daemon with the given logger.
+// This is the shared core between runDaemonChild and runForeground.
+func runDaemonWithLogger(ctx context.Context, daemonLogger *slog.Logger) error {
+	gitSvc := git.NewGitService()
+	sessSvc := session.NewSessionService()
+
+	wfCfg, err := workflow.LoadAndMerge(agentRepo)
+	if err != nil {
+		return fmt.Errorf("error loading workflow config: %w", err)
+	}
+
+	// Auto-detect container image if not set (should be cached from parent)
+	if wfCfg.Settings == nil || wfCfg.Settings.ContainerImage == "" {
+		detected := container.Detect(ctx, agentRepo)
+		image, err := container.EnsureImage(ctx, detected, version, daemonLogger)
+		if err != nil {
+			return fmt.Errorf("failed to auto-build container image: %w", err)
+		}
 		if wfCfg.Settings == nil {
 			wfCfg.Settings = &workflow.SettingsConfig{}
 		}
@@ -142,7 +369,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	}
 	cfg := agentconfig.NewAgentConfig(cfgOpts...)
 
-	// Initialize issue providers (nil configs — Asana/Linear are configured via workflow source, not config.json)
+	// Initialize issue providers
 	githubProvider := issues.NewGitHubProvider(gitSvc)
 	asanaProvider := issues.NewAsanaProvider(cfg)
 	linearProvider := issues.NewLinearProvider(cfg)
@@ -154,15 +381,12 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		opts = append(opts, daemon.WithOnce(true))
 	}
 	opts = append(opts, daemon.WithRepoFilter(agentRepo))
-	// Auto-merge is on by default; workflow settings can disable it
 	if wfCfg.Settings != nil && wfCfg.Settings.AutoMerge != nil {
 		opts = append(opts, daemon.WithAutoMerge(*wfCfg.Settings.AutoMerge))
 	}
 
-	// Create daemon
-	d := daemon.New(cfg, gitSvc, sessSvc, issueRegistry, agentLogger, opts...)
+	d := daemon.New(cfg, gitSvc, sessSvc, issueRegistry, daemonLogger, opts...)
 
-	// Run daemon
 	if err := d.Run(ctx); err != nil && ctx.Err() == nil {
 		return err
 	}
@@ -188,3 +412,90 @@ func resolveAgentRepo(ctx context.Context, repo string, getter cwdGitRootGetter)
 	}
 	return cwdRoot, nil
 }
+
+// formatUptime returns a human-friendly duration string (e.g. "2h 15m").
+func formatUptime(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	hours := int(d.Hours())
+	mins := int(d.Minutes()) % 60
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	}
+	return fmt.Sprintf("%dm", mins)
+}
+
+// uptimeFromLockFile returns uptime based on the lock file's modification time.
+func uptimeFromLockFile(repo string) time.Duration {
+	fp := daemonstate.LockFilePath(repo)
+	info, err := os.Stat(fp)
+	if err != nil {
+		return 0
+	}
+	return time.Since(info.ModTime())
+}
+
+// displaySummary prints a one-shot daemon status summary.
+func displaySummary(repo string) error {
+	pid, running := daemonstate.ReadLockStatus(repo)
+	if !running && pid == 0 {
+		fmt.Println("Daemon: not running")
+		return nil
+	}
+
+	status := "running"
+	if !running {
+		status = "dead"
+	}
+
+	uptime := uptimeFromLockFile(repo)
+	uptimeStr := ""
+	if running && uptime > 0 {
+		uptimeStr = fmt.Sprintf(", uptime %s", formatUptime(uptime))
+	}
+
+	fmt.Printf("Daemon: %s (PID %d%s)\n", status, pid, uptimeStr)
+	fmt.Printf("Repo:   %s\n", repo)
+
+	// Load state for counts
+	state, err := daemonstate.LoadDaemonState(repo)
+	if err == nil {
+		activeCount := 0
+		queuedCount := 0
+		completedCount := 0
+		failedCount := 0
+		for _, item := range state.WorkItems {
+			switch item.State {
+			case daemonstate.WorkItemActive:
+				activeCount++
+			case daemonstate.WorkItemQueued:
+				queuedCount++
+			case daemonstate.WorkItemCompleted:
+				completedCount++
+			case daemonstate.WorkItemFailed:
+				failedCount++
+			}
+		}
+
+		// Load max_concurrent from workflow config
+		wfCfg, _ := workflow.LoadAndMerge(repo)
+		maxConcurrent := 0
+		if wfCfg != nil && wfCfg.Settings != nil {
+			maxConcurrent = wfCfg.Settings.MaxConcurrent
+		}
+
+		if maxConcurrent > 0 {
+			fmt.Printf("Slots:  %d/%d active\n", activeCount, maxConcurrent)
+		} else {
+			fmt.Printf("Slots:  %d active\n", activeCount)
+		}
+		fmt.Printf("Active: %d  |  Queued: %d  |  Completed: %d  |  Failed: %d\n",
+			activeCount, queuedCount, completedCount, failedCount)
+	}
+
+	logPath, _ := logger.DefaultLogPath()
+	fmt.Printf("Logs:   %s\n", logPath)
+	return nil
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,9 @@ var rootCmd = &cobra.Command{
 	Long: `Persistent orchestrator daemon that manages the full lifecycle of work items:
 picking up issues, coding, PR creation, review feedback cycles, and final merge.
 
+By default, erg forks into the background and detaches from the terminal.
+Use -f/--foreground to stay attached with a live status display.
+
 The daemon is stoppable and restartable without losing track of in-flight work.
 State is persisted to ~/.erg/daemon-state.json.
 
@@ -36,10 +39,12 @@ as max_turns, max_duration, merge_method, and auto_merge can all be specified th
 All sessions are containerized (container = sandbox).
 
 Examples:
-  erg                          # Use current git repo as default
-  erg --repo owner/repo        # Run daemon (long-running)
-  erg --repo owner/repo --once # Process one tick and exit
-  erg --repo /path/to/repo     # Use filesystem path instead`,
+  erg                              # Fork/detach daemon for current repo
+  erg --repo owner/repo            # Fork/detach daemon for specific repo
+  erg -f --repo owner/repo         # Foreground with live status display
+  erg --repo owner/repo --once     # Run one tick (foreground), then exit
+  erg status                       # Show daemon status summary
+  erg --repo /path/to/repo         # Use filesystem path instead`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1164,6 +1164,12 @@
           </button>
         </div>
         <p>
+          This forks into the background, prints the daemon PID and log path,
+          and returns your terminal. Use <code>-f</code> to stay in the
+          foreground with a live status display, or <code>erg status</code> for
+          a one-shot summary.
+        </p>
+        <p>
           Label a GitHub issue with <code>queued</code> and the agent will pick
           it up on the next poll cycle.
         </p>
@@ -2408,11 +2414,19 @@ stateDiagram-v2
           <tbody>
             <tr>
               <td><code>erg --repo owner/repo</code></td>
-              <td>Run the headless daemon for a repository</td>
+              <td>Fork/detach daemon for a repository (prints PID and exits)</td>
+            </tr>
+            <tr>
+              <td><code>erg -f --repo owner/repo</code></td>
+              <td>Run in foreground with live status display</td>
             </tr>
             <tr>
               <td><code>erg --repo owner/repo --once</code></td>
-              <td>Process one tick and exit</td>
+              <td>Process one tick and exit (implies <code>-f</code>)</td>
+            </tr>
+            <tr>
+              <td><code>erg status</code></td>
+              <td>One-shot daemon status summary (PID, uptime, counts)</td>
             </tr>
             <tr>
               <td><code>erg --debug</code></td>
@@ -2441,10 +2455,6 @@ stateDiagram-v2
             <tr>
               <td><code>erg workflow visualize</code></td>
               <td>Emit a Mermaid diagram of the workflow</td>
-            </tr>
-            <tr>
-              <td><code>erg status</code></td>
-              <td>Show daemon status with workflow map</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Default `erg --repo` now forks/detaches via re-exec pattern, prints PID + log path, and exits
- New `-f`/`--foreground` flag stays attached with a live matrix dashboard
- `--once` implies `-f` (always foreground)
- `erg status` simplified to a one-shot summary (PID, uptime, slot counts)
- Docs updated across README, CLAUDE.md, and docs site

## Test plan
- [ ] `go test -p=1 -count=1 ./...` passes
- [ ] `./erg --repo owner/repo` forks into background, prints PID, exits
- [ ] `./erg -f --repo owner/repo` stays foreground with live display
- [ ] `./erg --once --repo owner/repo` runs one tick in foreground
- [ ] `erg status` shows one-shot summary
- [ ] Logs go to `~/.erg/logs/erg.log` (not stdout) in daemon mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)