### PR TITLE
fix: redirect daemon build-phase logs to file instead of stdout

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -94,12 +94,12 @@ func daemonize(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Temporary stdout logger for image build output the user should see
-	buildLogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
+	// Initialize file logger for the build phase — all output goes to log file, not stdout
+	logger.SetDebug(true)
+	defer logger.Close()
+	buildLogger := logger.Get()
 
-	// Load workflow config + build image (visible to user)
+	// Load workflow config + build image
 	wfCfg, err := workflow.LoadAndMerge(agentRepo)
 	if err != nil {
 		return fmt.Errorf("error loading workflow config: %w", err)


### PR DESCRIPTION
## Summary
Fixes daemon child process logging during the image build phase to write to the log file instead of stdout, preventing unwanted output when the daemon is forked/detached.

## Changes
- Replace temporary stdout-based `slog` handler with the standard file-based logger for build-phase output
- Call `logger.SetDebug(true)` and use `logger.Get()` so build logs go through the same file-based logging as the rest of the daemon
- Add regression test `TestSetDebug_BeforeInit_EnablesDebugLevel` to verify that `SetDebug(true)` before `Init()` correctly enables debug-level logging

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all tests pass, including the new logger regression test
- Start the daemon in forked mode (`./erg --repo owner/repo`) and confirm no build-phase log output appears on stdout
- Check `~/.erg/logs/erg.log` to confirm build-phase logs are written to the file

Fixes #85