### PR TITLE
feat(daemon): add format_command param to ai.code action

### DIFF
--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -303,6 +303,24 @@ func validateCodingParams(prefix string, params map[string]any) []ValidationErro
 		}
 	}
 
+	// Validate format_command if present (must be a non-empty string)
+	if fc, ok := params["format_command"]; ok {
+		switch v := fc.(type) {
+		case string:
+			if v == "" {
+				errs = append(errs, ValidationError{
+					Field:   prefix + ".params.format_command",
+					Message: "format_command must not be empty",
+				})
+			}
+		default:
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".params.format_command",
+				Message: "format_command must be a string",
+			})
+		}
+	}
+
 	return errs
 }
 

--- a/internal/workflow/validate_test.go
+++ b/internal/workflow/validate_test.go
@@ -280,6 +280,54 @@ func TestValidate(t *testing.T) {
 			wantFields: nil,
 		},
 		{
+			name: "ai.code empty format_command rejected",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "ai.code", Params: map[string]any{"format_command": ""}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.format_command"},
+		},
+		{
+			name: "ai.code non-string format_command rejected",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "ai.code", Params: map[string]any{"format_command": 42}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.format_command"},
+		},
+		{
+			name: "ai.code valid format_command accepted",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "ai.code", Params: map[string]any{"format_command": "go fmt ./..."}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: nil,
+		},
+		{
+			name: "ai.code valid format_command with format_message accepted",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "ai.code", Params: map[string]any{"format_command": "go fmt ./...", "format_message": "chore: go fmt"}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: nil,
+		},
+		{
 			name: "unknown state type",
 			cfg: &Config{
 				Start:  "x",


### PR DESCRIPTION
## Summary
Adds a `format_command` parameter to the `ai.code` workflow action, enabling automatic code formatting both during and after Claude's coding session.

## Changes
- Add `format_command` and `format_message` params to the `ai.code` action in `startCoding`, injecting formatter instructions into Claude's system prompt
- Run the formatter as a daemon-side safety net in `handleAsyncComplete` after successful coding, before PR creation
- Add workflow validation for `format_command` (must be a non-empty string if present)
- Add tests for formatter execution on success, skipping on failure, and skipping when no format command is configured
- Add validation tests for empty, non-string, and valid `format_command` values

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all new and existing tests pass
- Configure a workflow with `format_command: "go fmt ./..."` on an `ai.code` step and verify formatting is applied after coding completes
- Verify that formatter is skipped when the coding worker fails
- Verify validation rejects empty string and non-string values for `format_command`

Fixes #81