### PR TITLE
feat: track and display token and USD spend per daemon run

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -492,6 +492,17 @@ func displaySummary(repo string) error {
 		}
 		fmt.Printf("Active: %d  |  Queued: %d  |  Completed: %d  |  Failed: %d\n",
 			activeCount, queuedCount, completedCount, failedCount)
+
+		costUSD, outputTokens, inputTokens := state.GetSpend()
+		totalTokens := outputTokens + inputTokens
+		if costUSD > 0 || totalTokens > 0 {
+			fmt.Printf("Spend:  $%.4f  |  Tokens: %s (in: %s, out: %s)\n",
+				costUSD,
+				formatTokenCount(totalTokens),
+				formatTokenCount(inputTokens),
+				formatTokenCount(outputTokens),
+			)
+		}
 	}
 
 	logPath, _ := logger.DefaultLogPath()

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -182,7 +182,7 @@ func TestFormatStep_QueuedWithStep(t *testing.T) {
 
 func TestPrintFooter_WithMaxConcurrent(t *testing.T) {
 	var buf bytes.Buffer
-	printFooter(&buf, 2, 3, 1, 48291, true)
+	printFooter(&buf, 2, 3, 1, 48291, true, 0, 0)
 	out := buf.String()
 	if !strings.Contains(out, "Slots: 2/3 active") {
 		t.Errorf("expected 'Slots: 2/3 active' in output: %q", out)
@@ -197,7 +197,7 @@ func TestPrintFooter_WithMaxConcurrent(t *testing.T) {
 
 func TestPrintFooter_NoMaxConcurrent(t *testing.T) {
 	var buf bytes.Buffer
-	printFooter(&buf, 1, 0, 0, 0, false)
+	printFooter(&buf, 1, 0, 0, 0, false, 0, 0)
 	out := buf.String()
 	if !strings.Contains(out, "Slots: 1 active") {
 		t.Errorf("expected 'Slots: 1 active' in output: %q", out)
@@ -209,10 +209,31 @@ func TestPrintFooter_NoMaxConcurrent(t *testing.T) {
 
 func TestPrintFooter_DeadDaemon(t *testing.T) {
 	var buf bytes.Buffer
-	printFooter(&buf, 0, 0, 0, 12345, false)
+	printFooter(&buf, 0, 0, 0, 12345, false, 0, 0)
 	out := buf.String()
 	if !strings.Contains(out, "Daemon PID: 12345 (dead)") {
 		t.Errorf("expected '(dead)' indicator in output: %q", out)
+	}
+}
+
+func TestPrintFooter_WithSpend(t *testing.T) {
+	var buf bytes.Buffer
+	printFooter(&buf, 1, 2, 0, 999, true, 0.1234, 5500)
+	out := buf.String()
+	if !strings.Contains(out, "Spend: $0.1234") {
+		t.Errorf("expected spend in output: %q", out)
+	}
+	if !strings.Contains(out, "5.5K tokens") {
+		t.Errorf("expected token count in output: %q", out)
+	}
+}
+
+func TestPrintFooter_NoSpendWhenZero(t *testing.T) {
+	var buf bytes.Buffer
+	printFooter(&buf, 1, 2, 0, 999, true, 0, 0)
+	out := buf.String()
+	if strings.Contains(out, "Spend:") {
+		t.Errorf("expected no Spend line when cost and tokens are zero: %q", out)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -156,6 +156,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 	d.state = state
 
+	// Reset spend tracking so it reflects only the current daemon run.
+	d.state.ResetSpend()
+	if err := d.state.Save(); err != nil {
+		d.logger.Warn("failed to save state after resetting spend", "error", err)
+	}
+
 	// Load workflow configs for all repos
 	d.loadWorkflowConfigs()
 

--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -51,6 +51,15 @@ func (d *Daemon) IsWorkerRunning(sessionID string) bool {
 	return exists && !w.Done()
 }
 
+// RecordSpend adds token and cost data to the daemon's running totals and
+// persists the updated state to disk so that `erg status` reflects current spend.
+func (d *Daemon) RecordSpend(costUSD float64, outputTokens, inputTokens int) {
+	d.state.AddSpend(costUSD, outputTokens, inputTokens)
+	if err := d.state.Save(); err != nil {
+		d.logger.Warn("failed to save state after recording spend", "error", err)
+	}
+}
+
 // workItemView creates a read-only view of a work item for the engine.
 func (d *Daemon) workItemView(item *daemonstate.WorkItem) *workflow.WorkItemView {
 	// Use the session's actual repo path rather than d.repoFilter,

--- a/internal/worker/host.go
+++ b/internal/worker/host.go
@@ -37,6 +37,10 @@ type Host interface {
 	CleanupSession(ctx context.Context, sessionID string) error
 	SaveRunnerMessages(sessionID string, runner claude.RunnerInterface)
 	IsWorkerRunning(sessionID string) bool
+
+	// RecordSpend adds token and cost data from a completed Claude response
+	// to the daemon's running totals.
+	RecordSpend(costUSD float64, outputTokens, inputTokens int)
 }
 
 // SessionInfo holds the minimal info needed after creating a child session.


### PR DESCRIPTION
## Summary
Adds per-run cost and token usage tracking to the daemon, displaying accumulated spend in both `erg status` dashboard and one-shot summary views.

## Changes
- Add `TotalCostUSD`, `TotalOutputTokens`, and `TotalInputTokens` fields to `DaemonState` with thread-safe `AddSpend`, `ResetSpend`, and `GetSpend` methods
- Reset spend counters on daemon startup so tracking reflects only the current run
- Record spend from final Claude streaming stats chunks via new `Host.RecordSpend` interface method
- Display spend line in `erg status` dashboard footer and one-shot summary (hidden when zero)
- Add `formatTokenCount` helper for human-friendly token display (K/M suffixes)
- Add tests for spend accumulation, persistence, reset, footer rendering, and streaming integration

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all new and existing tests pass
- Start a daemon with `erg -f --repo owner/repo` and confirm spend line appears in live status after sessions complete
- Run `erg status` and verify spend is shown in the footer when non-zero and hidden when zero

Fixes #83