### PR TITLE
feat(cmd): add erg start/stop commands, make bare erg show help

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -38,24 +38,18 @@ func init() {
 	rootCmd.RunE = runAgent
 	rootCmd.Flags().BoolVar(&agentOnce, "once", false, "Run one tick and exit (vs continuous daemon)")
 	rootCmd.Flags().StringVar(&agentRepo, "repo", "", "Repo to poll (owner/repo or filesystem path)")
-	rootCmd.Flags().BoolVarP(&agentForeground, "foreground", "f", false, "Stay in foreground with live status display")
 	rootCmd.Flags().BoolVar(&agentDaemonMode, "_daemon", false, "Internal: run as detached daemon child")
 	rootCmd.Flags().MarkHidden("_daemon") //nolint:errcheck
+	rootCmd.Flags().MarkHidden("once")    //nolint:errcheck
+	rootCmd.Flags().MarkHidden("repo")    //nolint:errcheck
 }
 
 func runAgent(cmd *cobra.Command, args []string) error {
-	// --once implies foreground
-	if agentOnce {
-		agentForeground = true
-	}
-
 	if agentDaemonMode {
 		return runDaemonChild(cmd, args)
 	}
-	if agentForeground {
-		return runForeground(cmd, args)
-	}
-	return daemonize(cmd, args)
+	// When called as root command without --_daemon, show help
+	return cmd.Help()
 }
 
 // daemonize performs all setup visible to the user (prereqs, image build),

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -254,28 +254,6 @@ func TestBuildDaemonArgs_HiddenFlagAppended(t *testing.T) {
 
 // ---- runAgent flag logic ----
 
-func TestOnceImpliesForeground(t *testing.T) {
-	// Save and restore
-	origOnce := agentOnce
-	origFg := agentForeground
-	defer func() {
-		agentOnce = origOnce
-		agentForeground = origFg
-	}()
-
-	agentOnce = true
-	agentForeground = false
-
-	// runAgent will set agentForeground=true before dispatching.
-	// We can't run the full runAgent (needs prereqs), but we can test the flag logic.
-	if agentOnce {
-		agentForeground = true
-	}
-	if !agentForeground {
-		t.Error("expected --once to imply foreground mode")
-	}
-}
-
 func TestDaemonFlagIsHidden(t *testing.T) {
 	flag := rootCmd.Flags().Lookup("_daemon")
 	if flag == nil {
@@ -283,16 +261,6 @@ func TestDaemonFlagIsHidden(t *testing.T) {
 	}
 	if !flag.Hidden {
 		t.Error("expected --_daemon flag to be hidden")
-	}
-}
-
-func TestForegroundFlagExists(t *testing.T) {
-	flag := rootCmd.Flags().Lookup("foreground")
-	if flag == nil {
-		t.Fatal("expected --foreground flag to exist")
-	}
-	if flag.Shorthand != "f" {
-		t.Errorf("expected shorthand 'f', got %q", flag.Shorthand)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,27 +24,18 @@ var rootCmd = &cobra.Command{
 	Long: `Persistent orchestrator daemon that manages the full lifecycle of work items:
 picking up issues, coding, PR creation, review feedback cycles, and final merge.
 
-By default, erg forks into the background and detaches from the terminal.
-Use -f/--foreground to stay attached with a live status display.
+The daemon polls for issues labeled 'queued', creates containerized Claude Code
+sessions, monitors CI and review feedback, and auto-merges approved PRs.
 
-The daemon is stoppable and restartable without losing track of in-flight work.
-State is persisted to ~/.erg/daemon-state.json.
-
-If --repo is not specified and the current directory is inside a git repository,
-that repository is used as the default.
-
-Behavior is configured via .erg/workflow.yaml in your repository. Settings such
-as max_turns, max_duration, merge_method, and auto_merge can all be specified there.
-
-All sessions are containerized (container = sandbox).
+State is persisted to ~/.erg/ and survives restarts. Behavior is configured via
+.erg/workflow.yaml in your repository.
 
 Examples:
-  erg                              # Fork/detach daemon for current repo
-  erg --repo owner/repo            # Fork/detach daemon for specific repo
-  erg -f --repo owner/repo         # Foreground with live status display
-  erg --repo owner/repo --once     # Run one tick (foreground), then exit
+  erg start                        # Start daemon for current repo
+  erg start --repo owner/repo      # Start daemon for specific repo
+  erg start -f --repo owner/repo   # Foreground with live status display
   erg status                       # Show daemon status summary
-  erg --repo /path/to/repo         # Use filesystem path instead`,
+  erg stop                         # Stop the daemon gracefully`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	startRepo       string
+	startForeground bool
+	startOnce       bool
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the daemon",
+	Long: `Start the erg daemon for the given repository.
+
+By default, forks into the background and detaches from the terminal.
+Use -f/--foreground to stay attached with a live status display.
+
+Examples:
+  erg start                           # Start daemon for current repo
+  erg start --repo owner/repo         # Start daemon for specific repo
+  erg start -f --repo owner/repo      # Foreground with live status display
+  erg start --once --repo owner/repo  # Run one tick, then exit`,
+	RunE: runStart,
+}
+
+func init() {
+	startCmd.Flags().StringVar(&startRepo, "repo", "", "Repo to poll (owner/repo or filesystem path)")
+	startCmd.Flags().BoolVarP(&startForeground, "foreground", "f", false, "Stay in foreground with live status display")
+	startCmd.Flags().BoolVar(&startOnce, "once", false, "Run one tick and exit (vs continuous daemon)")
+	rootCmd.AddCommand(startCmd)
+}
+
+func runStart(cmd *cobra.Command, args []string) error {
+	// Set package-level vars used by daemonize/runForeground/runDaemonWithLogger
+	agentRepo = startRepo
+	agentForeground = startForeground
+	agentOnce = startOnce
+
+	// --once implies foreground
+	if agentOnce {
+		agentForeground = true
+	}
+
+	if agentForeground {
+		return runForeground(cmd, args)
+	}
+	return daemonize(cmd, args)
+}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestStartCmdForegroundFlagExists(t *testing.T) {
+	flag := startCmd.Flags().Lookup("foreground")
+	if flag == nil {
+		t.Fatal("expected --foreground flag on start command")
+	}
+	if flag.Shorthand != "f" {
+		t.Errorf("expected shorthand 'f', got %q", flag.Shorthand)
+	}
+}
+
+func TestStartCmdRepoFlagExists(t *testing.T) {
+	flag := startCmd.Flags().Lookup("repo")
+	if flag == nil {
+		t.Fatal("expected --repo flag on start command")
+	}
+}
+
+func TestStartCmdOnceFlagExists(t *testing.T) {
+	flag := startCmd.Flags().Lookup("once")
+	if flag == nil {
+		t.Fatal("expected --once flag on start command")
+	}
+}
+
+func TestStartOnceImpliesForeground(t *testing.T) {
+	// Save and restore package-level vars
+	origStartOnce := startOnce
+	origStartForeground := startForeground
+	origAgentOnce := agentOnce
+	origAgentForeground := agentForeground
+	defer func() {
+		startOnce = origStartOnce
+		startForeground = origStartForeground
+		agentOnce = origAgentOnce
+		agentForeground = origAgentForeground
+	}()
+
+	startOnce = true
+	startForeground = false
+
+	// Replicate the logic from runStart
+	agentOnce = startOnce
+	agentForeground = startForeground
+	if agentOnce {
+		agentForeground = true
+	}
+
+	if !agentForeground {
+		t.Error("expected --once to imply foreground mode")
+	}
+}
+
+func TestStartCmdRegisteredOnRoot(t *testing.T) {
+	found := false
+	for _, sub := range rootCmd.Commands() {
+		if sub.Use == "start" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'start' subcommand to be registered on rootCmd")
+	}
+}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/zhubert/erg/internal/daemonstate"
+	"github.com/zhubert/erg/internal/session"
+)
+
+var stopRepo string
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the daemon gracefully",
+	Long: `Send SIGTERM to the running daemon to trigger a graceful shutdown.
+
+The daemon will finish in-flight work before exiting.
+
+Examples:
+  erg stop                       # Stop daemon for current repo
+  erg stop --repo owner/repo     # Stop daemon for specific repo`,
+	RunE: runStop,
+}
+
+func init() {
+	stopCmd.Flags().StringVar(&stopRepo, "repo", "", "Repo whose daemon to stop (owner/repo or filesystem path)")
+	rootCmd.AddCommand(stopCmd)
+}
+
+func runStop(cmd *cobra.Command, args []string) error {
+	repo := stopRepo
+	if repo == "" {
+		sessSvc := session.NewSessionService()
+		var err error
+		repo, err = resolveAgentRepo(context.Background(), "", sessSvc)
+		if err != nil {
+			return err
+		}
+	}
+
+	pid, running := daemonstate.ReadLockStatus(repo)
+	if pid == 0 {
+		fmt.Println("Daemon is not running")
+		return nil
+	}
+
+	if !running {
+		fmt.Printf("Daemon process (PID %d) is no longer alive\n", pid)
+		fmt.Println("Use 'erg clean' to remove stale lock files")
+		return nil
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("could not find process %d: %w", pid, err)
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM to daemon (PID %d): %w", pid, err)
+	}
+
+	fmt.Printf("Sent SIGTERM to daemon (PID %d)\n", pid)
+	fmt.Println("Use 'erg status' to verify shutdown")
+	return nil
+}

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestStopCmdRepoFlagExists(t *testing.T) {
+	flag := stopCmd.Flags().Lookup("repo")
+	if flag == nil {
+		t.Fatal("expected --repo flag on stop command")
+	}
+}
+
+func TestStopCmdRegisteredOnRoot(t *testing.T) {
+	found := false
+	for _, sub := range rootCmd.Commands() {
+		if sub.Use == "stop" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'stop' subcommand to be registered on rootCmd")
+	}
+}
+
+// TestRunStop_NoDaemonRunning verifies that runStop prints "not running" and
+// returns no error when no lock file exists for the repo.
+func TestRunStop_NoDaemonRunning(t *testing.T) {
+	origRepo := stopRepo
+	defer func() { stopRepo = origRepo }()
+
+	// Use a path that will never have a lock file
+	stopRepo = filepath.Join(t.TempDir(), "no-daemon-repo")
+
+	out := captureStdoutStop(t, func() {
+		if err := runStop(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if out == "" {
+		t.Error("expected output when daemon is not running")
+	}
+}
+
+// TestRunStop_ExplicitRepoNoDaemon verifies runStop works with an explicit
+// --repo path that has no running daemon.
+func TestRunStop_ExplicitRepoNoDaemon(t *testing.T) {
+	origRepo := stopRepo
+	defer func() { stopRepo = origRepo }()
+
+	stopRepo = "/nonexistent/path/to/repo/with/no/daemon"
+
+	out := captureStdoutStop(t, func() {
+		if err := runStop(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if out == "" {
+		t.Error("expected 'Daemon is not running' output")
+	}
+}
+
+// captureStdoutStop captures os.Stdout output during f().
+func captureStdoutStop(t *testing.T, f func()) string {
+	t.Helper()
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}


### PR DESCRIPTION
## Summary
Restructures the CLI so that `erg` (bare command) shows help instead of launching the daemon directly. Daemon lifecycle is now managed through explicit `erg start` and `erg stop` subcommands.

## Changes
- Add `erg start` subcommand with `--repo`, `-f/--foreground`, and `--once` flags (moved from root command)
- Add `erg stop` subcommand that sends SIGTERM to a running daemon via its lock file PID
- Change bare `erg` to display help text instead of forking a daemon
- Hide `--once`, `--repo`, and `_daemon` flags on the root command
- Update root command description and examples to reflect new CLI structure
- Add tests for start/stop commands (flag existence, registration, --once implies foreground, no-daemon-running behavior)
- Remove obsolete tests for removed root-level flags

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all tests pass
- Run `erg` with no arguments and confirm help is displayed
- Run `erg start --help` and `erg stop --help` to verify flag documentation
- Start a daemon with `erg start --repo owner/repo` and stop it with `erg stop`

Fixes #90