### PR TITLE
docs: add format_command and format_message params to ai.code reference

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1516,6 +1516,26 @@
                     from the repo. Overrides the default coding prompt.
                   </td>
                 </tr>
+                <tr>
+                  <td>format_command</td>
+                  <td>string</td>
+                  <td><em>none</em></td>
+                  <td>
+                    Shell command to run as a formatter after coding completes
+                    (e.g. <code>go fmt ./...</code>). Claude is also instructed
+                    to run it before each commit. Omit to skip auto-formatting.
+                  </td>
+                </tr>
+                <tr>
+                  <td>format_message</td>
+                  <td>string</td>
+                  <td>Apply auto-formatting</td>
+                  <td>
+                    Commit message used when the daemon commits the
+                    post-coding format pass. Only used when
+                    <code>format_command</code> is set.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
Documents the `format_command` and `format_message` parameters for the `ai.code` workflow action in the reference docs.

## Changes
- Add `format_command` parameter: shell command to run as a formatter after coding completes
- Add `format_message` parameter: commit message used for the post-coding format pass

## Test plan
- Open `docs/index.html` in a browser and verify the new parameters render correctly in the `ai.code` action reference table
- Confirm descriptions, types, and defaults display as expected

Fixes #92