### PR TITLE
docs: document format_command and format_message on ai.fix_ci and pr.reviewed

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1606,6 +1606,28 @@
                   <td><em>built-in</em></td>
                   <td>Custom system prompt for the fix session.</td>
                 </tr>
+                <tr>
+                  <td>format_command</td>
+                  <td>string</td>
+                  <td><em>inherited</em></td>
+                  <td>
+                    Shell command to run as a formatter after each CI fix
+                    round (e.g. <code>go fmt ./...</code>). Overrides the
+                    value inherited from the <code>ai.code</code> step. Omit
+                    to keep the inherited formatter or skip formatting.
+                  </td>
+                </tr>
+                <tr>
+                  <td>format_message</td>
+                  <td>string</td>
+                  <td>Apply auto-formatting</td>
+                  <td>
+                    Commit message used when the daemon commits the
+                    post-fix-round format pass. Only used when
+                    <code>format_command</code> is set (directly or
+                    inherited).
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -2064,6 +2086,28 @@
                   <td>
                     Maximum number of feedback rounds before
                     auto-addressing stops.
+                  </td>
+                </tr>
+                <tr>
+                  <td>format_command</td>
+                  <td>string</td>
+                  <td><em>inherited</em></td>
+                  <td>
+                    Shell command to run as a formatter after each review
+                    feedback round (e.g. <code>go fmt ./...</code>). Overrides
+                    the value inherited from the <code>ai.code</code> step.
+                    Omit to keep the inherited formatter or skip formatting.
+                  </td>
+                </tr>
+                <tr>
+                  <td>format_message</td>
+                  <td>string</td>
+                  <td>Apply auto-formatting</td>
+                  <td>
+                    Commit message used when the daemon commits the
+                    post-feedback format pass. Only used when
+                    <code>format_command</code> is set (directly or
+                    inherited).
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## Summary
Add missing documentation for `format_command` and `format_message` parameters on the `ai.fix_ci` and `pr.reviewed` workflow steps.

## Changes
- Document `format_command` param on `ai.fix_ci` step (shell command to run formatter after each CI fix round)
- Document `format_message` param on `ai.fix_ci` step (commit message for post-fix format pass)
- Document `format_command` param on `pr.reviewed` step (shell command to run formatter after each review feedback round)
- Document `format_message` param on `pr.reviewed` step (commit message for post-feedback format pass)
- Note inheritance behavior from `ai.code` step for both parameters

## Test plan
- Open the docs page locally and verify the new parameter rows render correctly in both the `ai.fix_ci` and `pr.reviewed` tables
- Confirm descriptions accurately reflect the existing implementation behavior

Fixes #98