### PR TITLE
feat(claude): redact secrets from transcripts and stream logs

### DIFF
--- a/internal/claude/redactor.go
+++ b/internal/claude/redactor.go
@@ -1,0 +1,44 @@
+package claude
+
+import (
+	"os"
+	"strings"
+)
+
+// knownSecretEnvVars is the list of environment variable names whose values
+// should never appear in transcripts or stream logs.
+var knownSecretEnvVars = []string{
+	"ANTHROPIC_API_KEY",
+	"CLAUDE_CODE_OAUTH_TOKEN",
+	"LINEAR_API_KEY",
+	"ASANA_PAT",
+	"GITHUB_TOKEN",
+}
+
+// Redactor replaces known secret values with a placeholder to prevent
+// sensitive data from appearing in transcripts and stream log files.
+type Redactor struct {
+	secrets []string
+}
+
+// NewRedactor creates a Redactor populated with secret values read from the
+// current environment. Non-empty values of knownSecretEnvVars are collected
+// so they can be scrubbed from any text that passes through Redact.
+func NewRedactor() *Redactor {
+	var secrets []string
+	for _, name := range knownSecretEnvVars {
+		if val := os.Getenv(name); val != "" {
+			secrets = append(secrets, val)
+		}
+	}
+	return &Redactor{secrets: secrets}
+}
+
+// Redact replaces every occurrence of a known secret value in text with
+// "[REDACTED]". Returns text unchanged when no secrets are configured.
+func (r *Redactor) Redact(text string) string {
+	for _, secret := range r.secrets {
+		text = strings.ReplaceAll(text, secret, "[REDACTED]")
+	}
+	return text
+}

--- a/internal/claude/redactor_test.go
+++ b/internal/claude/redactor_test.go
@@ -1,0 +1,126 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactor_Redact(t *testing.T) {
+	tests := []struct {
+		name    string
+		secrets []string
+		input   string
+		want    string
+	}{
+		{
+			name:    "no secrets configured",
+			secrets: nil,
+			input:   "hello world",
+			want:    "hello world",
+		},
+		{
+			name:    "single secret replaced",
+			secrets: []string{"sk-ant-abc123"},
+			input:   `{"api_key":"sk-ant-abc123"}`,
+			want:    `{"api_key":"[REDACTED]"}`,
+		},
+		{
+			name:    "multiple secrets replaced",
+			secrets: []string{"token-abc", "key-xyz"},
+			input:   "use token-abc and key-xyz",
+			want:    "use [REDACTED] and [REDACTED]",
+		},
+		{
+			name:    "secret appears multiple times",
+			secrets: []string{"s3cr3t"},
+			input:   "s3cr3t is s3cr3t",
+			want:    "[REDACTED] is [REDACTED]",
+		},
+		{
+			name:    "no secret present in text",
+			secrets: []string{"sk-ant-abc123"},
+			input:   "no sensitive data here",
+			want:    "no sensitive data here",
+		},
+		{
+			name:    "empty input",
+			secrets: []string{"sk-ant-abc123"},
+			input:   "",
+			want:    "",
+		},
+		{
+			name:    "secret in JSON stream line",
+			secrets: []string{"sk-ant-realkey"},
+			input:   `{"type":"result","content":"key is sk-ant-realkey done"}`,
+			want:    `{"type":"result","content":"key is [REDACTED] done"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Redactor{secrets: tc.secrets}
+			got := r.Redact(tc.input)
+			if got != tc.want {
+				t.Errorf("Redact(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewRedactor_ReadsEnvVars(t *testing.T) {
+	// Set known env var and confirm NewRedactor picks it up
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+	t.Setenv("GITHUB_TOKEN", "ghp_testtoken")
+
+	r := NewRedactor()
+
+	if len(r.secrets) < 2 {
+		t.Fatalf("expected at least 2 secrets, got %d", len(r.secrets))
+	}
+
+	input := "key=sk-ant-test-key token=ghp_testtoken"
+	got := r.Redact(input)
+
+	if strings.Contains(got, "sk-ant-test-key") {
+		t.Error("ANTHROPIC_API_KEY value not redacted")
+	}
+	if strings.Contains(got, "ghp_testtoken") {
+		t.Error("GITHUB_TOKEN value not redacted")
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Error("expected [REDACTED] placeholder in output")
+	}
+}
+
+func TestNewRedactor_IgnoresEmptyEnvVars(t *testing.T) {
+	// Unset all known vars to ensure empty values are skipped
+	for _, name := range knownSecretEnvVars {
+		t.Setenv(name, "")
+	}
+
+	r := NewRedactor()
+
+	if len(r.secrets) != 0 {
+		t.Errorf("expected 0 secrets when env vars are empty, got %d", len(r.secrets))
+	}
+}
+
+func TestNewRedactor_AllKnownVarsRecognised(t *testing.T) {
+	// Each known env var should be collected when set
+	for _, name := range knownSecretEnvVars {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(name, "super-secret-value")
+			r := NewRedactor()
+			found := false
+			for _, s := range r.secrets {
+				if s == "super-secret-value" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("env var %s not collected by NewRedactor", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds a `Redactor` that scrubs known secret values (API keys, tokens) from transcript messages and stream log files, preventing sensitive credentials from being persisted to disk.

## Changes
- Add `Redactor` type that reads secret values from known environment variables (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `LINEAR_API_KEY`, `ASANA_PAT`, `GITHUB_TOKEN`) at initialization
- Apply redaction to stream log lines before writing to log files
- Apply redaction to all messages appended to the transcript (assistant and user messages)
- Comprehensive test coverage for the redactor including env var detection, multiple secrets, edge cases, and all known variable names

## Test plan
- `go test -p=1 -count=1 ./internal/claude/...` — verifies redactor unit tests pass
- Set `ANTHROPIC_API_KEY` or `GITHUB_TOKEN` in the environment, run a session, and confirm the values do not appear in `~/.erg/logs/stream-*.log` or transcript messages

Fixes #100