### PR TITLE
feat(status): add --tail flag for live split-screen session log view

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	statusRepo string
+	statusTail bool
 )
 
 var statusCmd = &cobra.Command{
@@ -28,12 +29,14 @@ and work item counts.
 
 Examples:
   erg status                     # Show status for current repo
-  erg status --repo owner/repo   # Check specific repo`,
+  erg status --repo owner/repo   # Check specific repo
+  erg status --tail              # Live split-screen log view per active session`,
 	RunE: runStatus,
 }
 
 func init() {
 	statusCmd.Flags().StringVar(&statusRepo, "repo", "", "Repo to check status for (owner/repo or filesystem path)")
+	statusCmd.Flags().BoolVar(&statusTail, "tail", false, "Show live split-screen log view for active sessions")
 	rootCmd.AddCommand(statusCmd)
 }
 
@@ -48,6 +51,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if statusTail {
+		return runTailView(repo)
+	}
 	return displaySummary(repo)
 }
 

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -1,0 +1,363 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/zhubert/erg/internal/daemonstate"
+	"github.com/zhubert/erg/internal/logger"
+)
+
+// ioctlWinsize is the TIOCGWINSZ ioctl argument struct (Linux/macOS).
+type ioctlWinsize struct {
+	Row    uint16
+	Col    uint16
+	Xpixel uint16
+	Ypixel uint16
+}
+
+// terminalSize returns the current terminal dimensions (rows, cols).
+// Falls back to (24, 80) if size cannot be determined.
+func terminalSize() (int, int) {
+	ws := &ioctlWinsize{}
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(os.Stdout.Fd()),
+		uintptr(syscall.TIOCGWINSZ),
+		uintptr(unsafe.Pointer(ws)),
+	)
+	if errno != 0 || ws.Row == 0 || ws.Col == 0 {
+		return 24, 80
+	}
+	return int(ws.Row), int(ws.Col)
+}
+
+// tailStreamMsg is a minimal struct for parsing stream log JSON entries.
+type tailStreamMsg struct {
+	Type    string `json:"type"`
+	Message struct {
+		Content []struct {
+			Type  string          `json:"type"`
+			Text  string          `json:"text"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		} `json:"content"`
+	} `json:"message"`
+}
+
+// tailToolVerb returns a short display verb for the given tool name.
+func tailToolVerb(name string) string {
+	switch name {
+	case "Read":
+		return "Reading"
+	case "Edit":
+		return "Editing"
+	case "Write":
+		return "Writing"
+	case "Glob", "Grep":
+		return "Searching"
+	case "Bash":
+		return "Running"
+	case "Task":
+		return "Delegating"
+	case "WebFetch":
+		return "Fetching"
+	case "WebSearch":
+		return "Searching"
+	case "TodoWrite":
+		return "Updating todos"
+	default:
+		return "Using " + name
+	}
+}
+
+// tailToolDesc extracts a short description from tool input JSON.
+func tailToolDesc(name string, input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(input, &m); err != nil {
+		return ""
+	}
+	field := ""
+	switch name {
+	case "Read", "Edit", "Write":
+		field = "file_path"
+	case "Glob":
+		field = "pattern"
+	case "Grep":
+		field = "pattern"
+	case "Bash":
+		field = "command"
+	case "Task":
+		field = "description"
+	case "WebFetch":
+		field = "url"
+	case "WebSearch":
+		field = "query"
+	}
+	if field != "" {
+		if v, ok := m[field].(string); ok && v != "" {
+			// For file paths shorten to last component
+			if name == "Read" || name == "Edit" || name == "Write" {
+				parts := strings.Split(v, "/")
+				v = parts[len(parts)-1]
+			}
+			if len(v) > 35 {
+				v = v[:32] + "..."
+			}
+			return v
+		}
+	}
+	return ""
+}
+
+// readStreamLogLines reads and parses a stream log file for a session,
+// returning display lines (text content and tool use summaries).
+func readStreamLogLines(sessionID string) ([]string, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("no session ID")
+	}
+	logPath, err := logger.StreamLogPath(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var lines []string
+	dec := json.NewDecoder(f)
+	for {
+		var msg tailStreamMsg
+		if err := dec.Decode(&msg); err != nil {
+			// EOF or parse error — stop reading
+			break
+		}
+		if msg.Type != "assistant" {
+			continue
+		}
+		for _, c := range msg.Message.Content {
+			switch c.Type {
+			case "text":
+				// Split multi-line text into individual lines
+				for _, ln := range strings.Split(c.Text, "\n") {
+					ln = strings.TrimRight(ln, "\r")
+					if strings.TrimSpace(ln) != "" {
+						lines = append(lines, ln)
+					}
+				}
+			case "tool_use":
+				verb := tailToolVerb(c.Name)
+				desc := tailToolDesc(c.Name, c.Input)
+				if desc != "" {
+					lines = append(lines, fmt.Sprintf("[%s: %s]", verb, desc))
+				} else {
+					lines = append(lines, fmt.Sprintf("[%s]", verb))
+				}
+			}
+		}
+	}
+	return lines, nil
+}
+
+// fitLine truncates or pads s to exactly width runes.
+func fitLine(s string, width int) string {
+	runes := []rune(s)
+	if len(runes) > width {
+		if width > 3 {
+			return string(runes[:width-3]) + "..."
+		}
+		return string(runes[:width])
+	}
+	// Pad with spaces
+	return s + strings.Repeat(" ", width-len(runes))
+}
+
+// renderTailView renders the split-screen tail view to w.
+// items are the active work items to display; termRows/termCols are terminal dimensions.
+func renderTailView(w io.Writer, items []*daemonstate.WorkItem, termRows, termCols int) {
+	n := len(items)
+	if n == 0 {
+		fmt.Fprintln(w, "No active sessions to tail.")
+		return
+	}
+
+	// Compute column widths — divide terminal evenly, separator between columns
+	// Total separators = n-1 (each "│" is 1 char)
+	colWidth := (termCols - (n - 1)) / n
+	if colWidth < 10 {
+		colWidth = 10
+	}
+
+	// Content rows available: terminal rows minus 3 header rows (title, step, separator)
+	contentRows := termRows - 4
+	if contentRows < 1 {
+		contentRows = 1
+	}
+
+	// Build each column's lines
+	type colData struct {
+		header    string
+		subheader string
+		lines     []string
+	}
+	cols := make([]colData, n)
+	for i, item := range items {
+		header := formatIssue(item)
+		step := item.CurrentStep
+		if step == "" {
+			step = "pending"
+		}
+		phase := item.Phase
+		if phase == "" {
+			phase = "idle"
+		}
+		cols[i].header = header
+		cols[i].subheader = fmt.Sprintf("%s / %s", step, phase)
+
+		logLines, err := readStreamLogLines(item.SessionID)
+		if err != nil {
+			if item.SessionID == "" {
+				cols[i].lines = []string{"(waiting for session)"}
+			} else {
+				cols[i].lines = []string{"(no log yet)"}
+			}
+		} else if len(logLines) == 0 {
+			cols[i].lines = []string{"(no output yet)"}
+		} else {
+			// Take last contentRows lines
+			if len(logLines) > contentRows {
+				logLines = logLines[len(logLines)-contentRows:]
+			}
+			cols[i].lines = logLines
+		}
+	}
+
+	// Print header row (issue title)
+	for i, col := range cols {
+		if i > 0 {
+			fmt.Fprint(w, "│")
+		}
+		fmt.Fprint(w, fitLine(col.header, colWidth))
+	}
+	fmt.Fprintln(w)
+
+	// Print subheader row (step / phase)
+	for i, col := range cols {
+		if i > 0 {
+			fmt.Fprint(w, "│")
+		}
+		fmt.Fprint(w, fitLine(col.subheader, colWidth))
+	}
+	fmt.Fprintln(w)
+
+	// Print separator row
+	for i := range cols {
+		if i > 0 {
+			fmt.Fprint(w, "┼")
+		}
+		fmt.Fprint(w, strings.Repeat("─", colWidth))
+	}
+	fmt.Fprintln(w)
+
+	// Print content rows — row-by-row across all columns
+	for row := 0; row < contentRows; row++ {
+		for i, col := range cols {
+			if i > 0 {
+				fmt.Fprint(w, "│")
+			}
+			line := ""
+			if row < len(col.lines) {
+				line = col.lines[row]
+			}
+			fmt.Fprint(w, fitLine(line, colWidth))
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// runTailView continuously renders a live split-screen view of active session logs.
+func runTailView(repo string) error {
+	// Handle Ctrl+C gracefully
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	// Hide cursor for cleaner output
+	fmt.Print("\033[?25l")
+	defer fmt.Print("\033[?25h\n")
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	// Draw immediately on first run
+	if err := drawTailFrame(repo); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			clearScreen()
+			return nil
+		case <-ticker.C:
+			if err := drawTailFrame(repo); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// drawTailFrame loads state and renders one frame of the tail view.
+func drawTailFrame(repo string) error {
+	state, err := daemonstate.LoadDaemonState(repo)
+	if err != nil {
+		clearScreen()
+		fmt.Printf("Error loading state: %v\n", err)
+		return nil
+	}
+
+	// Collect active items (non-terminal, any state) sorted by creation time
+	var items []*daemonstate.WorkItem
+	for _, item := range state.WorkItems {
+		if !item.IsTerminal() {
+			items = append(items, item)
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+
+	rows, cols := terminalSize()
+
+	clearScreen()
+
+	if len(items) == 0 {
+		fmt.Println("No active work items.")
+		fmt.Printf("\n  Updated: %s  (every 1s, Ctrl+C to quit)\n", time.Now().Format("15:04:05"))
+		return nil
+	}
+
+	renderTailView(os.Stdout, items, rows-2, cols)
+	fmt.Printf("  Updated: %s  (every 1s, Ctrl+C to quit)\n", time.Now().Format("15:04:05"))
+	return nil
+}

--- a/cmd/tail_test.go
+++ b/cmd/tail_test.go
@@ -1,0 +1,477 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zhubert/erg/internal/config"
+	"github.com/zhubert/erg/internal/daemonstate"
+	"github.com/zhubert/erg/internal/paths"
+)
+
+// ---- tailToolVerb ----
+
+func TestTailToolVerb_KnownTools(t *testing.T) {
+	cases := []struct {
+		tool string
+		want string
+	}{
+		{"Read", "Reading"},
+		{"Edit", "Editing"},
+		{"Write", "Writing"},
+		{"Glob", "Searching"},
+		{"Grep", "Searching"},
+		{"Bash", "Running"},
+		{"Task", "Delegating"},
+		{"WebFetch", "Fetching"},
+		{"WebSearch", "Searching"},
+		{"TodoWrite", "Updating todos"},
+	}
+	for _, c := range cases {
+		got := tailToolVerb(c.tool)
+		if got != c.want {
+			t.Errorf("tailToolVerb(%q) = %q, want %q", c.tool, got, c.want)
+		}
+	}
+}
+
+func TestTailToolVerb_Unknown(t *testing.T) {
+	got := tailToolVerb("MyCustomTool")
+	if !strings.HasPrefix(got, "Using") {
+		t.Errorf("expected 'Using ...' for unknown tool, got %q", got)
+	}
+}
+
+// ---- tailToolDesc ----
+
+func TestTailToolDesc_ReadTool(t *testing.T) {
+	input := json.RawMessage(`{"file_path": "/workspace/internal/foo/bar.go"}`)
+	got := tailToolDesc("Read", input)
+	if got != "bar.go" {
+		t.Errorf("expected 'bar.go', got %q", got)
+	}
+}
+
+func TestTailToolDesc_BashTool(t *testing.T) {
+	input := json.RawMessage(`{"command": "go test ./..."}`)
+	got := tailToolDesc("Bash", input)
+	if got != "go test ./..." {
+		t.Errorf("expected 'go test ./...', got %q", got)
+	}
+}
+
+func TestTailToolDesc_GrepTool(t *testing.T) {
+	input := json.RawMessage(`{"pattern": "func main"}`)
+	got := tailToolDesc("Grep", input)
+	if got != "func main" {
+		t.Errorf("expected 'func main', got %q", got)
+	}
+}
+
+func TestTailToolDesc_LongValue_Truncated(t *testing.T) {
+	longVal := strings.Repeat("x", 50)
+	input := json.RawMessage(`{"command": "` + longVal + `"}`)
+	got := tailToolDesc("Bash", input)
+	if len([]rune(got)) > 35 {
+		t.Errorf("expected truncation to 35 chars, got %d: %q", len(got), got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("expected truncated string to end with '...', got %q", got)
+	}
+}
+
+func TestTailToolDesc_EmptyInput(t *testing.T) {
+	got := tailToolDesc("Read", json.RawMessage{})
+	if got != "" {
+		t.Errorf("expected empty string for empty input, got %q", got)
+	}
+}
+
+func TestTailToolDesc_InvalidJSON(t *testing.T) {
+	got := tailToolDesc("Read", json.RawMessage(`not-json`))
+	if got != "" {
+		t.Errorf("expected empty string for invalid JSON, got %q", got)
+	}
+}
+
+func TestTailToolDesc_UnknownTool(t *testing.T) {
+	input := json.RawMessage(`{"something": "value"}`)
+	got := tailToolDesc("MyTool", input)
+	// Unknown tool has no field mapping, returns ""
+	if got != "" {
+		t.Errorf("expected '' for unknown tool, got %q", got)
+	}
+}
+
+// ---- fitLine ----
+
+func TestFitLine_ExactWidth(t *testing.T) {
+	got := fitLine("hello", 5)
+	if got != "hello" {
+		t.Errorf("expected 'hello', got %q", got)
+	}
+}
+
+func TestFitLine_ShortPadded(t *testing.T) {
+	got := fitLine("hi", 5)
+	if got != "hi   " {
+		t.Errorf("expected 'hi   ', got %q", got)
+	}
+	if len(got) != 5 {
+		t.Errorf("expected length 5, got %d", len(got))
+	}
+}
+
+func TestFitLine_LongTruncated(t *testing.T) {
+	got := fitLine("hello world", 8)
+	if len(got) != 8 {
+		t.Errorf("expected length 8, got %d: %q", len(got), got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("expected truncated string to end with '...', got %q", got)
+	}
+}
+
+func TestFitLine_VeryNarrow(t *testing.T) {
+	// width < 3 → truncate without ellipsis
+	got := fitLine("hello", 2)
+	if len(got) != 2 {
+		t.Errorf("expected length 2, got %d: %q", len(got), got)
+	}
+}
+
+func TestFitLine_Empty(t *testing.T) {
+	got := fitLine("", 5)
+	if got != "     " {
+		t.Errorf("expected 5 spaces, got %q", got)
+	}
+}
+
+// ---- readStreamLogLines ----
+
+// writeStreamLog writes a fake stream log to a temp directory and returns cleanup.
+func writeStreamLog(t *testing.T, sessionID string, entries []map[string]any) func() {
+	t.Helper()
+
+	// Set up a temp dir for logs
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	paths.Reset()
+
+	logsDir := filepath.Join(tmpDir, "erg", "logs")
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+
+	logPath := filepath.Join(logsDir, "stream-"+sessionID+".log")
+	f, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("failed to create stream log: %v", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, entry := range entries {
+		if err := enc.Encode(entry); err != nil {
+			t.Fatalf("failed to write log entry: %v", err)
+		}
+	}
+
+	return func() {
+		paths.Reset()
+	}
+}
+
+func TestReadStreamLogLines_TextContent(t *testing.T) {
+	cleanup := writeStreamLog(t, "sess-001", []map[string]any{
+		{
+			"type": "assistant",
+			"message": map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "Hello, world!\nSecond line."},
+				},
+			},
+		},
+	})
+	defer cleanup()
+
+	lines, err := readStreamLogLines("sess-001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "Hello, world!" {
+		t.Errorf("expected first line 'Hello, world!', got %q", lines[0])
+	}
+	if lines[1] != "Second line." {
+		t.Errorf("expected second line 'Second line.', got %q", lines[1])
+	}
+}
+
+func TestReadStreamLogLines_ToolUse(t *testing.T) {
+	cleanup := writeStreamLog(t, "sess-002", []map[string]any{
+		{
+			"type": "assistant",
+			"message": map[string]any{
+				"content": []map[string]any{
+					{
+						"type":  "tool_use",
+						"name":  "Read",
+						"input": map[string]any{"file_path": "/workspace/main.go"},
+					},
+				},
+			},
+		},
+	})
+	defer cleanup()
+
+	lines, err := readStreamLogLines("sess-002")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "Reading") {
+		t.Errorf("expected 'Reading' in tool use line, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "main.go") {
+		t.Errorf("expected 'main.go' in tool use line, got %q", lines[0])
+	}
+}
+
+func TestReadStreamLogLines_SkipsNonAssistant(t *testing.T) {
+	cleanup := writeStreamLog(t, "sess-003", []map[string]any{
+		{
+			"type": "user",
+			"message": map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "User message — should be skipped"},
+				},
+			},
+		},
+		{
+			"type":    "result",
+			"subtype": "success",
+		},
+	})
+	defer cleanup()
+
+	lines, err := readStreamLogLines("sess-003")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 0 {
+		t.Errorf("expected 0 lines (non-assistant skipped), got %d: %v", len(lines), lines)
+	}
+}
+
+func TestReadStreamLogLines_EmptySessionID(t *testing.T) {
+	_, err := readStreamLogLines("")
+	if err == nil {
+		t.Error("expected error for empty session ID, got nil")
+	}
+}
+
+func TestReadStreamLogLines_MissingFile(t *testing.T) {
+	// Use a temp dir with no log files
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmpDir)
+	paths.Reset()
+	defer paths.Reset()
+
+	_, err := readStreamLogLines("nonexistent-session")
+	if err == nil {
+		t.Error("expected error for missing log file, got nil")
+	}
+}
+
+func TestReadStreamLogLines_SkipsBlankTextLines(t *testing.T) {
+	cleanup := writeStreamLog(t, "sess-004", []map[string]any{
+		{
+			"type": "assistant",
+			"message": map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "\n\n  \nActual content\n\n"},
+				},
+			},
+		},
+	})
+	defer cleanup()
+
+	lines, err := readStreamLogLines("sess-004")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			t.Errorf("expected no blank lines in output, got %q", line)
+		}
+	}
+	if len(lines) != 1 || lines[0] != "Actual content" {
+		t.Errorf("expected ['Actual content'], got %v", lines)
+	}
+}
+
+// ---- renderTailView ----
+
+func newWorkItem(id, title, step, phase, sessionID string) *daemonstate.WorkItem {
+	return &daemonstate.WorkItem{
+		ID:            id,
+		IssueRef:      config.IssueRef{Source: "github", ID: id, Title: title},
+		State:         daemonstate.WorkItemActive,
+		CurrentStep:   step,
+		Phase:         phase,
+		SessionID:     sessionID,
+		CreatedAt:     time.Now(),
+		StepEnteredAt: time.Now(),
+	}
+}
+
+func TestRenderTailView_NoItems(t *testing.T) {
+	var buf bytes.Buffer
+	renderTailView(&buf, nil, 24, 80)
+	out := buf.String()
+	if !strings.Contains(out, "No active") {
+		t.Errorf("expected 'No active' message, got %q", out)
+	}
+}
+
+func TestRenderTailView_SingleItem(t *testing.T) {
+	item := newWorkItem("42", "Fix login bug", "coding", "async_pending", "")
+	var buf bytes.Buffer
+	renderTailView(&buf, []*daemonstate.WorkItem{item}, 24, 80)
+	out := buf.String()
+
+	// Header should contain the issue
+	if !strings.Contains(out, "#42") {
+		t.Errorf("expected '#42' in output, got %q", out)
+	}
+	// Subheader should contain step and phase
+	if !strings.Contains(out, "coding") {
+		t.Errorf("expected 'coding' in output, got %q", out)
+	}
+	if !strings.Contains(out, "async_pending") {
+		t.Errorf("expected 'async_pending' in output, got %q", out)
+	}
+}
+
+func TestRenderTailView_MultipleItems_HasSeparators(t *testing.T) {
+	items := []*daemonstate.WorkItem{
+		newWorkItem("1", "First issue", "coding", "idle", ""),
+		newWorkItem("2", "Second issue", "await_review", "idle", ""),
+	}
+	var buf bytes.Buffer
+	renderTailView(&buf, items, 24, 80)
+	out := buf.String()
+
+	// Should have column separators
+	if !strings.Contains(out, "│") {
+		t.Errorf("expected column separator '│' in output, got %q", out)
+	}
+	// Should have both issue headers
+	if !strings.Contains(out, "#1") {
+		t.Errorf("expected '#1' in output, got %q", out)
+	}
+	if !strings.Contains(out, "#2") {
+		t.Errorf("expected '#2' in output, got %q", out)
+	}
+}
+
+func TestRenderTailView_HasHorizontalSeparator(t *testing.T) {
+	item := newWorkItem("5", "Test issue", "coding", "idle", "")
+	var buf bytes.Buffer
+	renderTailView(&buf, []*daemonstate.WorkItem{item}, 24, 80)
+	out := buf.String()
+
+	if !strings.Contains(out, "─") {
+		t.Errorf("expected horizontal separator '─' in output, got %q", out)
+	}
+	if !strings.Contains(out, "┼") || true {
+		// ┼ only appears when there are multiple columns — skip check for single column
+	}
+}
+
+func TestRenderTailView_NoSessionID_ShowsWaiting(t *testing.T) {
+	item := newWorkItem("7", "Queued item", "coding", "idle", "")
+	item.SessionID = "" // ensure no session ID
+	var buf bytes.Buffer
+	renderTailView(&buf, []*daemonstate.WorkItem{item}, 24, 80)
+	out := buf.String()
+
+	if !strings.Contains(out, "waiting for session") {
+		t.Errorf("expected 'waiting for session' for item without session ID, got %q", out)
+	}
+}
+
+func TestRenderTailView_LineWidths_ConsistentPerRow(t *testing.T) {
+	const (
+		termCols = 90
+		n        = 3
+	)
+	items := []*daemonstate.WorkItem{
+		newWorkItem("1", "Alpha", "step_one", "idle", ""),
+		newWorkItem("2", "Beta", "step_two", "idle", ""),
+		newWorkItem("3", "Gamma", "step_three", "idle", ""),
+	}
+	var buf bytes.Buffer
+	renderTailView(&buf, items, 10, termCols)
+	out := buf.String()
+
+	// Column width = (termCols - (n-1)) / n (integer division)
+	// Total rendered width = colWidth*n + (n-1) separators
+	colWidth := (termCols - (n - 1)) / n
+	expectedWidth := colWidth*n + (n - 1)
+
+	// Every non-empty line should have exactly the computed width
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		if len([]rune(line)) != expectedWidth {
+			t.Errorf("line %d width = %d, expected %d: %q", i, len([]rune(line)), expectedWidth, line)
+		}
+	}
+}
+
+func TestRenderTailView_WithStreamLog(t *testing.T) {
+	cleanup := writeStreamLog(t, "active-session", []map[string]any{
+		{
+			"type": "assistant",
+			"message": map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "Implementing the feature now."},
+					{
+						"type":  "tool_use",
+						"name":  "Bash",
+						"input": map[string]any{"command": "go test ./..."},
+					},
+				},
+			},
+		},
+	})
+	defer cleanup()
+
+	item := newWorkItem("10", "Add feature", "coding", "async_pending", "active-session")
+	var buf bytes.Buffer
+	renderTailView(&buf, []*daemonstate.WorkItem{item}, 24, 80)
+	out := buf.String()
+
+	if !strings.Contains(out, "Implementing the feature now.") {
+		t.Errorf("expected text content in output, got %q", out)
+	}
+	if !strings.Contains(out, "Running") {
+		t.Errorf("expected 'Running' tool verb in output, got %q", out)
+	}
+	if !strings.Contains(out, "go test") {
+		t.Errorf("expected 'go test' in output, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a `--tail` flag to `erg status` that provides a live, continuously-updating split-screen terminal view of active session logs, showing what each Claude session is doing in real time.

## Changes
- Add `--tail` flag to the `status` command that launches a live TUI view
- Implement split-screen renderer that divides the terminal into columns per active work item
- Parse stream log JSON to extract assistant text and tool use summaries with human-readable verbs
- Auto-refresh every 1 second with clean terminal output and graceful Ctrl+C handling
- Add comprehensive tests for tool verb mapping, tool description extraction, line fitting, stream log parsing, and the split-screen renderer

## Test plan
- Run `go test -p=1 -count=1 ./cmd/...` to verify all new tests pass
- `erg status --tail` with active sessions shows a split-screen view with session logs
- `erg status --tail` with no active sessions shows "No active work items"
- Ctrl+C cleanly exits the tail view and restores the cursor
- `erg status` without `--tail` continues to work as before

Fixes #101