### PR TITLE
docs: rebuild CLAUDE.md with only essential agent guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,27 +9,15 @@ Guidance for Claude Code when working with this repository.
 - Every new function or method must have corresponding unit tests
 - Every bug fix must include a regression test
 - Run `go test -p=1 -count=1 ./...` before considering any task complete
-- Aim for high coverage (80%+) on new code
 - Use table-driven tests where appropriate
 - Test edge cases and error conditions, not just happy paths
 - If `go test` fails with a segfault or signal, retry — it may be a transient container issue
 
-## Build and Run
+## Build and Test
 
 ```bash
-go build -o erg .       # Build
-go test -p=1 -count=1 ./...     # Test (use -p=1 in containers to avoid Go toolchain segfaults)
-
-./erg --version         # Show version
-./erg --debug           # Enable debug logging (on by default)
-./erg -q                # Quiet mode (info level only)
-
-./erg --repo owner/repo         # Fork/detach daemon (prints PID, exits)
-./erg -f --repo owner/repo     # Foreground with live status display
-./erg --repo owner/repo --once  # Process one tick and exit (implies -f)
-./erg status                    # One-shot daemon status summary
-./erg clean                     # Clear daemon state and lock files
-./erg clean -y                  # Clear without confirmation prompt
+go build -o erg .
+go test -p=1 -count=1 ./...
 ```
 
 ## Debug Logs
@@ -61,15 +49,15 @@ internal/
   paths/              Path resolution, XDG support (leaf)
   exec/               Command execution + MockExecutor (leaf)
   cli/                CLI prerequisite validation (leaf)
-  logger/             Structured slog logging (depends on: paths)
-  config/             Session, IssueRef, MCPServer, Config (depends on: paths)
-  git/                GitService, PR/branch ops (depends on: exec, logger)
-  issues/             Provider interface: GitHub, Asana, Linear (depends on: git)
-  mcp/                MCP protocol, socket server/client (depends on: logger)
-  claude/             RunnerInterface, process mgmt, tool sets (depends on: mcp)
-  session/            SessionService (depends on: exec, config, logger, paths)
-  manager/            SessionManager (depends on: claude, config, git, logger, mcp)
-  agentconfig/        Config interface (leaf package, no internal deps)
+  logger/             Structured slog logging
+  config/             Session, IssueRef, MCPServer, Config
+  git/                GitService, PR/branch ops
+  issues/             Provider interface: GitHub, Asana, Linear
+  mcp/                MCP protocol, socket server/client
+  claude/             RunnerInterface, process mgmt, tool sets
+  session/            SessionService
+  manager/            SessionManager
+  agentconfig/        Config interface (leaf, no internal deps)
   container/          Container lifecycle and Docker management
   daemonstate/        Daemon state persistence and file-based locking (leaf)
   worker/             SessionWorker — manages a single session's lifecycle
@@ -85,11 +73,6 @@ worker    → agentconfig, claude, manager, session, config, git, ...
 workflow  → (leaf)
 ```
 
-### Key Dependencies
-
-- `github.com/spf13/cobra` — CLI framework
-- `gopkg.in/yaml.v3` — YAML parsing for workflow configs
-
 ### Key Patterns
 
 - **Functional options**: `daemon.Option` configures Daemon via `With*()` functions
@@ -97,22 +80,6 @@ workflow  → (leaf)
 - **Host interface**: `worker.Host` abstracts the daemon so SessionWorker doesn't depend on it directly
 - **Worker goroutines**: Each session gets a `SessionWorker` with its own goroutine and select loop
 - **State machine**: Daemon uses `workflow.Engine` for configurable state machines per repo
-- **Graceful shutdown**: Context cancellation with SIGINT/SIGTERM handling; second signal force-exits
-- **Daemon lock**: File-based lock with stale PID detection prevents multiple instances per repo
-
-### Container Mode
-
-All sessions are containerized — the container IS the sandbox. Claude runs with `--dangerously-skip-permissions` inside Docker. Interactive prompts route through the MCP server over TCP.
-
-### Workflow Configuration
-
-Per-repo workflow config via `.erg/workflow.yaml`. Override chain: CLI flag > workflow yaml > config.json > default.
-
-**State types**: `task` (execute action), `wait` (poll event with timeout), `choice` (conditional branch), `pass` (inject data), `succeed`/`fail` (terminal).
-
-**Error recovery**: Task states support `retry` (max_attempts, interval, backoff) and `catch` (route errors to recovery states).
-
-**Hooks**: `before` hooks run before step execution (failure blocks the step). `after` hooks run after completion (fire-and-forget).
 
 ---
 
@@ -130,14 +97,3 @@ Per-repo workflow config via `.erg/workflow.yaml`. Override chain: CLI flag > wo
 1. Add flag variable and `Flags().XxxVar()` call in `cmd/agent.go`'s `init()`
 2. Map to `daemon.Option` in `runAgent()`
 3. Add corresponding `WithXxx()` option function in `internal/daemon/daemon.go`
-
----
-
-## Releasing
-
-```bash
-./scripts/release.sh patch            # v0.0.3 -> v0.0.4
-./scripts/release.sh minor            # v0.0.3 -> v0.1.0
-./scripts/release.sh major            # v0.0.3 -> v1.0.0
-./scripts/release.sh patch --dry-run  # Dry run
-```


### PR DESCRIPTION
## Summary
Streamline CLAUDE.md by removing operational details that aren't needed for agent context, keeping only the guidance that directly helps Claude Code work effectively in this codebase.

## Changes
- Remove verbose CLI usage examples (build/run flags, daemon invocations)
- Remove coverage target guidance (80%+ line removed)
- Strip dependency annotations from package structure descriptions
- Remove "Key Dependencies" section (cobra, yaml)
- Remove detailed sections: Container Mode, Workflow Configuration, Graceful shutdown, Daemon lock
- Remove Releasing section (release script usage)
- Rename "Build and Run" to "Build and Test" with just the two essential commands

## Test plan
- Verify CLAUDE.md renders correctly in GitHub
- Confirm remaining content still covers testing requirements, architecture overview, and implementation guides

Fixes #105