### PR TITLE
docs: make pipeline diagram responsive on small screens

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -477,6 +477,11 @@
         color: var(--text-dim);
       }
 
+      .sf-step {
+        display: flex;
+        align-items: center;
+      }
+
       .sf-arrow {
         color: var(--text-dim);
         font-size: 0.75rem;
@@ -822,6 +827,7 @@
 
         .state-flow {
           padding: 1rem 0;
+          flex-wrap: wrap;
         }
       }
 
@@ -1211,31 +1217,41 @@
 
         <h3>Pipeline overview</h3>
         <div class="state-flow">
-          <div class="sf-node">
-            <div class="sf-box sf-task">coding</div>
-            <span class="sf-type">ai.code</span>
+          <div class="sf-step">
+            <div class="sf-node">
+              <div class="sf-box sf-task">coding</div>
+              <span class="sf-type">ai.code</span>
+            </div>
+            <span class="sf-arrow">&rarr;</span>
           </div>
-          <span class="sf-arrow">&rarr;</span>
-          <div class="sf-node">
-            <div class="sf-box sf-task">open_pr</div>
-            <span class="sf-type">github.create_pr</span>
+          <div class="sf-step">
+            <div class="sf-node">
+              <div class="sf-box sf-task">open_pr</div>
+              <span class="sf-type">github.create_pr</span>
+            </div>
+            <span class="sf-arrow">&rarr;</span>
           </div>
-          <span class="sf-arrow">&rarr;</span>
-          <div class="sf-node">
-            <div class="sf-box sf-wait">await_review</div>
-            <span class="sf-type">pr.reviewed</span>
+          <div class="sf-step">
+            <div class="sf-node">
+              <div class="sf-box sf-wait">await_review</div>
+              <span class="sf-type">pr.reviewed</span>
+            </div>
+            <span class="sf-arrow">&rarr;</span>
           </div>
-          <span class="sf-arrow">&rarr;</span>
-          <div class="sf-node">
-            <div class="sf-box sf-wait">await_ci</div>
-            <span class="sf-type">ci.complete</span>
+          <div class="sf-step">
+            <div class="sf-node">
+              <div class="sf-box sf-wait">await_ci</div>
+              <span class="sf-type">ci.complete</span>
+            </div>
+            <span class="sf-arrow">&rarr;</span>
           </div>
-          <span class="sf-arrow">&rarr;</span>
-          <div class="sf-node">
-            <div class="sf-box sf-task">merge</div>
-            <span class="sf-type">github.merge</span>
+          <div class="sf-step">
+            <div class="sf-node">
+              <div class="sf-box sf-task">merge</div>
+              <span class="sf-type">github.merge</span>
+            </div>
+            <span class="sf-arrow">&rarr;</span>
           </div>
-          <span class="sf-arrow">&rarr;</span>
           <div class="sf-node">
             <div class="sf-box sf-done">done</div>
             <span class="sf-type">succeed</span>


### PR DESCRIPTION
## Summary
Wraps pipeline diagram steps so they flow naturally on narrow viewports instead of overflowing.

## Changes
- Wrap each node+arrow pair in a `.sf-step` flex container so arrows stay visually attached to their preceding node
- Add `flex-wrap: wrap` to `.state-flow` at the mobile breakpoint
- Add `.sf-step` base style with `display: flex; align-items: center`

## Test plan
- Open `docs/index.html` in a browser and resize to a narrow width (~375px); verify the pipeline diagram wraps gracefully without horizontal overflow
- Confirm the diagram still displays in a single row on wider screens

Fixes #109