### PR TITLE
feat(daemon): unqueue issues when existing PR already addresses them

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/zhubert/erg/internal/session"
 )
 
+// discardLogger returns a slog.Logger that discards all output. Useful in tests.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
 // testConfig creates a minimal config for testing.
 func testConfig() *config.Config {
 	return &config.Config{

--- a/internal/issues/github.go
+++ b/internal/issues/github.go
@@ -67,6 +67,26 @@ func (p *GitHubProvider) GetPRLinkText(issue Issue) string {
 	return fmt.Sprintf("Fixes #%s", issue.ID)
 }
 
+// RemoveLabel removes a label from a GitHub issue.
+// Implements ProviderActions.
+func (p *GitHubProvider) RemoveLabel(ctx context.Context, repoPath string, issueID string, label string) error {
+	issueNum, err := strconv.Atoi(issueID)
+	if err != nil {
+		return fmt.Errorf("invalid GitHub issue ID %q: %w", issueID, err)
+	}
+	return p.gitService.RemoveIssueLabel(ctx, repoPath, issueNum, label)
+}
+
+// Comment adds a comment to a GitHub issue.
+// Implements ProviderActions.
+func (p *GitHubProvider) Comment(ctx context.Context, repoPath string, issueID string, body string) error {
+	issueNum, err := strconv.Atoi(issueID)
+	if err != nil {
+		return fmt.Errorf("invalid GitHub issue ID %q: %w", issueID, err)
+	}
+	return p.gitService.CommentOnIssue(ctx, repoPath, issueNum, body)
+}
+
 // GetIssueNumber returns the issue number as an int (for backwards compatibility).
 // Returns 0 if the ID is not a valid number.
 func GetIssueNumber(issue Issue) int {

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -65,6 +65,17 @@ type Provider interface {
 	GetPRLinkText(issue Issue) string
 }
 
+// ProviderActions extends Provider with write operations for issue management.
+// Providers that support label removal and commenting should implement this interface.
+// Operations are expected to be best-effort; callers should log but not fail on errors.
+type ProviderActions interface {
+	// RemoveLabel removes a label/tag from an issue/task.
+	RemoveLabel(ctx context.Context, repoPath string, issueID string, label string) error
+
+	// Comment adds a comment/story to an issue/task.
+	Comment(ctx context.Context, repoPath string, issueID string, body string) error
+}
+
 // ProviderRegistry holds all available issue providers.
 type ProviderRegistry struct {
 	providers []Provider


### PR DESCRIPTION
## Summary
Adds a pre-flight check during issue polling that detects when a GitHub issue already has an open or merged PR addressing it, and unqueues the issue instead of spawning a redundant coding session. Also changes the "no changes" behavior in `createPRAction` to unqueue (leave open) rather than close the issue.

## Changes
- Add `GetLinkedPRsForIssue` to GitService using GitHub GraphQL API to find cross-referenced PRs for an issue
- Add `checkLinkedPRsAndUnqueue` pre-flight check in the polling loop that skips issues with existing open/merged PRs
- Add `unqueueIssue` method that removes the "queued" label and comments on the issue without closing it
- Change `createPRAction` no-changes path from closing the issue to unqueueing it
- Add `ProviderActions` interface implementations (`RemoveLabel`, `Comment`) for all three providers: GitHub, Asana, and Linear
- Extract `linearGraphQL` helper to reduce duplication in Linear provider

## Test plan
- Unit tests for `GetLinkedPRsForIssue`: open/merged PRs, excludes closed, deduplication, error handling, non-PR nodes
- Unit tests for `checkLinkedPRsAndUnqueue`: linked PR found, no PRs, GraphQL error (fail-open), non-numeric ID
- Unit tests for `unqueueIssue`: GitHub provider, no ProviderActions, no repo path
- Unit tests for `RemoveLabel` and `Comment` on all three providers (GitHub, Asana, Linear) including error cases
- Run `go test -p=1 -count=1 ./...`

Fixes #117