### PR TITLE
feat(workflow): add asana.comment and linear.comment actions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2106,6 +2106,92 @@
           </div>
         </div>
 
+        <h3>Asana actions</h3>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">asana.comment</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Posts a comment on the Asana task associated with the work item.
+            Requires the <code>ASANA_PAT</code> environment variable to be set
+            and an Asana provider registered for the repository.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>body</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>
+                    Comment text. Prefix with <code>file:</code> to load
+                    content from a repo path, e.g.
+                    <code>file:.erg/comments/msg.md</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
+        <h3>Linear actions</h3>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">linear.comment</span>
+            <span class="badge badge-sync">sync</span>
+          </div>
+          <p class="action-desc">
+            Posts a comment on the Linear issue associated with the work item.
+            Requires the <code>LINEAR_API_KEY</code> environment variable to be
+            set and a Linear provider registered for the repository.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>body</td>
+                  <td>string</td>
+                  <td><em>required</em></td>
+                  <td>
+                    Comment text. Prefix with <code>file:</code> to load
+                    content from a repo path, e.g.
+                    <code>file:.erg/comments/msg.md</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <p class="param-none">None.</p>
+          </div>
+        </div>
+
         <h3 id="actions-git">Git actions</h3>
 
         <div class="action-ref">

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -782,6 +782,8 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("ai.fix_ci", &fixCIAction{daemon: d})
 	registry.Register("git.format", &formatAction{daemon: d})
 	registry.Register("git.rebase", &rebaseAction{daemon: d})
+	registry.Register("asana.comment", &asanaCommentAction{daemon: d})
+	registry.Register("linear.comment", &linearCommentAction{daemon: d})
 	return registry
 }
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -141,6 +141,8 @@ var ValidActions = map[string]bool{
 	"ai.fix_ci":             true,
 	"git.format":            true,
 	"git.rebase":            true,
+	"asana.comment":         true,
+	"linear.comment":        true,
 }
 
 // ValidEvents is the set of recognized event names for wait states.


### PR DESCRIPTION
## Summary
Adds `asana.comment` and `linear.comment` workflow actions that post comments on Asana tasks and Linear issues via the ProviderActions interface.

## Changes
- Add `asanaCommentAction` and `linearCommentAction` action types with source-matching validation
- Add shared `commentViaProvider` helper on Daemon that resolves the comment body (including `file:` prefix support), validates the provider, and calls `ProviderActions.Comment`
- Register both actions in the daemon's action registry and add them to `ValidActions`
- Add documentation for both actions in `docs/index.html`
- Add comprehensive tests covering success, source mismatch (no-op), empty body, missing provider, provider error, and missing work item

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/... ./internal/workflow/...` to verify all new and existing tests pass
- Verify that source-mismatch cases return success without calling the provider (no-op behavior)
- Verify that missing provider, empty body, and API errors are properly surfaced

Fixes #123