### PR TITLE
feat(issues): add ProviderActions interface and unqueue issues on no-changes

### DIFF
--- a/internal/issues/github.go
+++ b/internal/issues/github.go
@@ -67,6 +67,26 @@ func (p *GitHubProvider) GetPRLinkText(issue Issue) string {
 	return fmt.Sprintf("Fixes #%s", issue.ID)
 }
 
+// RemoveLabel removes a label from a GitHub issue.
+// Implements ProviderActions.
+func (p *GitHubProvider) RemoveLabel(ctx context.Context, repoPath string, issueID string, label string) error {
+	num, err := strconv.Atoi(issueID)
+	if err != nil {
+		return fmt.Errorf("invalid github issue number %q: %w", issueID, err)
+	}
+	return p.gitService.RemoveIssueLabel(ctx, repoPath, num, label)
+}
+
+// Comment adds a comment on a GitHub issue.
+// Implements ProviderActions.
+func (p *GitHubProvider) Comment(ctx context.Context, repoPath string, issueID string, body string) error {
+	num, err := strconv.Atoi(issueID)
+	if err != nil {
+		return fmt.Errorf("invalid github issue number %q: %w", issueID, err)
+	}
+	return p.gitService.CommentOnIssue(ctx, repoPath, num, body)
+}
+
 // GetIssueNumber returns the issue number as an int (for backwards compatibility).
 // Returns 0 if the ID is not a valid number.
 func GetIssueNumber(issue Issue) int {

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -65,6 +65,16 @@ type Provider interface {
 	GetPRLinkText(issue Issue) string
 }
 
+// ProviderActions extends Provider with write operations for issue management.
+// Providers that support these operations should implement this interface.
+// Operations are best-effort — callers should log but not fail on errors.
+type ProviderActions interface {
+	// RemoveLabel removes a label/tag from an issue/task.
+	RemoveLabel(ctx context.Context, repoPath string, issueID string, label string) error
+	// Comment adds a comment/story to an issue/task.
+	Comment(ctx context.Context, repoPath string, issueID string, body string) error
+}
+
 // ProviderRegistry holds all available issue providers.
 type ProviderRegistry struct {
 	providers []Provider


### PR DESCRIPTION
## Summary
Instead of closing issues when a coding session produces no changes, this PR removes the "queued" label and leaves an explanatory comment, keeping the issue open for humans to re-triage. This is implemented via a new `ProviderActions` interface that all three issue providers (GitHub, Asana, Linear) now support.

## Changes
- Add `ProviderActions` interface with `RemoveLabel` and `Comment` methods to `internal/issues/provider.go`
- Implement `ProviderActions` for GitHub, Asana, and Linear providers
- Add `unqueueIssue` method to the daemon that removes the queued label and comments on the issue
- Replace `closeIssueGracefully` with `unqueueIssue` in the no-changes code path of `createPRAction`
- Add `GetLinkedPRsForIssue` to `GitService` for querying PRs linked to an issue via the timeline API

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all existing tests pass
- Verify that when a coding session makes no changes, the issue is unqueued (label removed, comment added) rather than closed
- Test with each provider type (GitHub, Asana, Linear) to confirm `RemoveLabel` and `Comment` work against their respective APIs

Fixes #117