### PR TITLE
feat: use live tail view for erg start -f foreground mode

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -290,23 +290,26 @@ func runForeground(_ *cobra.Command, _ []string) error {
 		return <-daemonErr
 	}
 
-	// Auto-refreshing status display
-	ticker := time.NewTicker(5 * time.Second)
+	// Live tail view (same as `erg status --tail`)
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	// Initial display
-	clearScreen()
-	_ = displayDashboard(agentRepo)
+	// Hide cursor for cleaner output
+	fmt.Print("\033[?25l")
+	defer fmt.Print("\033[?25h\n")
+
+	// Draw immediately on first run
+	_ = drawTailFrame(agentRepo)
 
 	for {
 		select {
 		case err := <-daemonErr:
 			return err
 		case <-ctx.Done():
+			clearScreen()
 			return nil
 		case <-ticker.C:
-			clearScreen()
-			_ = displayDashboard(agentRepo)
+			_ = drawTailFrame(agentRepo)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Replaces the custom dashboard display in `erg start -f` foreground mode with the same live tail view used by `erg status --tail`, providing a consistent and flicker-free experience.

## Changes
- Replace `displayDashboard` with `drawTailFrame` in foreground mode's refresh loop
- Increase refresh rate from 5s to 1s to match tail view behavior
- Hide cursor during foreground display for cleaner output
- Remove the now-unused `displayDashboard` function from `cmd/status.go`
- Add tests for `drawTailFrame` covering no state file, empty state, and active work items

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all tests pass
- Run `erg start -f` and confirm the live tail view renders correctly
- Compare output with `erg status --tail` to verify consistency

Fixes #128