### PR TITLE
feat: auto-detect merge conflicts and rebase PRs

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -781,6 +781,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("github.request_review", &requestReviewAction{daemon: d})
 	registry.Register("ai.fix_ci", &fixCIAction{daemon: d})
 	registry.Register("git.format", &formatAction{daemon: d})
+	registry.Register("git.rebase", &rebaseAction{daemon: d})
 	return registry
 }
 

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -920,3 +920,142 @@ func TestCheckCIComplete_CIFailing_FixPolicy(t *testing.T) {
 		t.Error("expected ci_passed=false in data")
 	}
 }
+
+func TestCheckCIComplete_Conflicting(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// PR is CONFLICTING
+	mergeableJSON, _ := json.Marshal(struct {
+		Mergeable string `json:"mergeable"`
+	}{Mergeable: "CONFLICTING"})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Stdout: mergeableJSON,
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.autoMerge = true
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_ci",
+	})
+
+	checker := NewEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{"on_failure": "fix"})
+	view := d.workItemView(d.state.GetWorkItem("item-1"))
+
+	fired, data, err := checker.checkCIComplete(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fired {
+		t.Error("expected fired=true when PR is conflicting")
+	}
+	if data == nil || data["conflicting"] != true {
+		t.Error("expected conflicting=true in data")
+	}
+}
+
+func TestCheckCIComplete_MergeableCheckFails_FallsThroughToCI(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Mergeable check fails (gh pr view returns error)
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Err: errGHFailed,
+	})
+
+	// CI is passing
+	checksJSON, _ := json.Marshal([]struct {
+		State string `json:"state"`
+	}{{State: "SUCCESS"}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "checks"}, exec.MockResponse{
+		Stdout: checksJSON,
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.autoMerge = true
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_ci",
+	})
+
+	checker := NewEventChecker(d)
+	params := workflow.NewParamHelper(nil)
+	view := d.workItemView(d.state.GetWorkItem("item-1"))
+
+	fired, data, err := checker.checkCIComplete(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should fall through to CI check and fire with ci_passed
+	if !fired {
+		t.Error("expected fired=true when CI passes (merge check fell through)")
+	}
+	if data == nil || data["ci_passed"] != true {
+		t.Error("expected ci_passed=true in data")
+	}
+}
+
+func TestCheckCIComplete_MergeableUnknown_FallsThroughToCI(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Mergeable returns UNKNOWN
+	mergeableJSON, _ := json.Marshal(struct {
+		Mergeable string `json:"mergeable"`
+	}{Mergeable: "UNKNOWN"})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Stdout: mergeableJSON,
+	})
+
+	// CI is pending
+	checksJSON, _ := json.Marshal([]struct {
+		State string `json:"state"`
+	}{{State: "PENDING"}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "checks"}, exec.MockResponse{
+		Stdout: checksJSON,
+		Err:    errGHFailed,
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.autoMerge = true
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_ci",
+	})
+
+	checker := NewEventChecker(d)
+	params := workflow.NewParamHelper(nil)
+	view := d.workItemView(d.state.GetWorkItem("item-1"))
+
+	fired, _, err := checker.checkCIComplete(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// UNKNOWN mergeable falls through, CI pending means not fired
+	if fired {
+		t.Error("expected fired=false when CI pending (merge status unknown)")
+	}
+}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -140,6 +140,7 @@ var ValidActions = map[string]bool{
 	"github.request_review": true,
 	"ai.fix_ci":             true,
 	"git.format":            true,
+	"git.rebase":            true,
 }
 
 // ValidEvents is the set of recognized event names for wait states.


### PR DESCRIPTION
## Summary
- When a PR has merge conflicts with main, the daemon now automatically detects this and rebases the branch onto main, then re-enters the CI wait loop
- Previously, conflicting PRs would get stuck: CI wouldn't run, the `ci.complete` event would never fire, and the PR would time out after 2 hours
- The rebase is mechanical (`git fetch && git rebase && git push --force-with-lease`) — if real file-level conflicts exist, the rebase fails and the workflow goes to `failed`

## Changes
- **`internal/git/github.go`**: Add `MergeableStatus` type, `CheckPRMergeableStatus()` (uses `gh pr view --json mergeable`), and `RebaseBranch()` (fetch + rebase + force-push with conflict abort)
- **`internal/daemon/events.go`**: Enhance `checkCIComplete` to check PR mergeable status before CI status — if CONFLICTING, fires with `{conflicting: true}`
- **`internal/workflow/config.go`**: Register `git.rebase` as a valid action
- **`internal/workflow/defaults.go`**: Add `conflicting → rebase` choice (first in `check_ci_result`) and `rebase` state with `max_rebase_rounds: 3`
- **`internal/daemon/actions.go`**: Add `rebaseAction` — checks max rounds, refreshes session, calls `RebaseBranch()`
- **`internal/daemon/daemon.go`**: Register `git.rebase` in action registry
- **`internal/workflow/validate.go`**: Add `validateRebaseParams`, fix latent cycle detection bug (DFS returned true for allowed cycles, causing false positives)
- **`cmd/status.go`**: Update `primaryWorkflowPath` to prefer forward choices over loop-back choices in display

## Test plan
- [x] `go build -o erg .` passes
- [x] `go test -p=1 -count=1 ./...` passes (all 18 packages)
- [x] 8 new tests for `CheckPRMergeableStatus` and `RebaseBranch` (success, error, conflict abort, push fail)
- [x] 3 new tests for conflict detection in `checkCIComplete` (CONFLICTING fires, check failure falls through, UNKNOWN falls through)
- [x] 7 new tests for `rebaseAction` (missing item, no session, max rounds, success, rebase failure) + table test for `getRebaseRounds`
- [x] Updated default workflow tests verify 3 choices, rebase state config, and validation passes
- [x] New validation tests for `max_rebase_rounds <= 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)