### PR TITLE
fix: prevent status --tail flickering by caching last known log lines

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -313,8 +313,12 @@ func runForeground(_ *cobra.Command, _ []string) error {
 	fmt.Print("\033[?25l")
 	defer fmt.Print("\033[?25h\n")
 
+	// logCache retains the most recent log lines per work item to avoid
+	// flickering during session transitions (see renderTailView).
+	logCache := make(map[string][]string)
+
 	// Draw immediately on first run
-	_ = drawTailFrame(agentRepo)
+	_ = drawTailFrame(agentRepo, logCache)
 
 	for {
 		select {
@@ -324,7 +328,7 @@ func runForeground(_ *cobra.Command, _ []string) error {
 			clearScreen()
 			return nil
 		case <-ticker.C:
-			_ = drawTailFrame(agentRepo)
+			_ = drawTailFrame(agentRepo, logCache)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Fixes flickering in the `status --tail` view that occurs during session transitions when a new session ID is assigned but the stream log file hasn't been written yet.

## Changes
- Add a `logCache` map (`work item ID → last known log lines`) that persists across render frames
- When fresh log content is read, update the cache for that work item
- When the log file is missing or empty, fall back to cached lines instead of showing "(no log yet)"
- Thread the cache through `drawTailFrame` and `renderTailView` in both the tail command and foreground agent mode
- Handle nil cache gracefully (no-op, falls through to default messages)

## Test plan
- `go test -p=1 -count=1 ./...` — all tests pass
- New tests cover:
  - Cache fallback when stream log file is missing
  - Cache fallback when stream log exists but has no assistant messages
  - Cache is updated when fresh log content is available
  - Nil cache does not panic and falls through to default behavior
- Manual: run `erg status --tail` while sessions are transitioning and verify no flicker

Fixes #132