### PR TITLE
refactor(workflow): remove DefaultConfig alias and simplify GetSession

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -69,7 +69,7 @@ func runWorkflowValidate(cmd *cobra.Command, args []string) error {
 
 	if cfg == nil {
 		fmt.Fprintln(os.Stderr, "No .erg/workflow.yaml found, using defaults.")
-		cfg = workflow.DefaultConfig()
+		cfg = workflow.DefaultWorkflowConfig()
 	}
 
 	errs := workflow.Validate(cfg)

--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -264,7 +264,7 @@ func TestCommentIssueAction_Execute_GhError(t *testing.T) {
 func TestDaemon_CodingParamsExtractsLimits(t *testing.T) {
 	// Verify that max_turns and max_duration params on the coding state
 	// are correctly read by the ParamHelper, matching the startCoding logic.
-	wfCfg := workflow.DefaultConfig()
+	wfCfg := workflow.DefaultWorkflowConfig()
 	wfCfg.States["coding"].Params["max_turns"] = 10
 	wfCfg.States["coding"].Params["max_duration"] = "5m"
 
@@ -301,7 +301,7 @@ func TestDaemon_CodingParamsDefaultsWhenAbsent(t *testing.T) {
 
 func TestDefaultWorkflowConfig_SupervisorFalse(t *testing.T) {
 	// The default workflow config should have supervisor: false for coding state
-	wfCfg := workflow.DefaultConfig()
+	wfCfg := workflow.DefaultWorkflowConfig()
 	codingState := wfCfg.States["coding"]
 	if codingState == nil {
 		t.Fatal("expected coding state in default workflow config")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -822,7 +822,7 @@ func (d *Daemon) getWorkflowConfig(repoPath string) *workflow.Config {
 	if cfg, ok := d.workflowConfigs[repoPath]; ok {
 		return cfg
 	}
-	return workflow.DefaultConfig()
+	return workflow.DefaultWorkflowConfig()
 }
 
 // getEngine returns the workflow engine for a repo, or creates one with defaults.
@@ -831,7 +831,7 @@ func (d *Daemon) getEngine(repoPath string) *workflow.Engine {
 		return engine
 	}
 	// Create a default engine on the fly
-	cfg := workflow.DefaultConfig()
+	cfg := workflow.DefaultWorkflowConfig()
 	registry := d.buildActionRegistry()
 	checker := NewEventChecker(d)
 	return workflow.NewEngine(cfg, registry, checker, d.logger)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1684,7 +1684,7 @@ func TestProcessWaitItems_PreservesPhaseSetByEventHandler(t *testing.T) {
 		itemID:   "item-phase",
 		newPhase: "addressing_feedback",
 	}
-	wfCfg := workflow.DefaultConfig()
+	wfCfg := workflow.DefaultWorkflowConfig()
 	registry := d.buildActionRegistry()
 	engine := workflow.NewEngine(wfCfg, registry, checker, d.logger)
 	d.engines = map[string]*workflow.Engine{"/test/repo": engine}

--- a/internal/daemon/polling_test.go
+++ b/internal/daemon/polling_test.go
@@ -35,7 +35,7 @@ func TestFetchIssuesForProvider_GitHub(t *testing.T) {
 
 	d := testDaemonWithExec(cfg, mockExec)
 
-	wfCfg := workflow.DefaultConfig()
+	wfCfg := workflow.DefaultWorkflowConfig()
 	wfCfg.Source.Provider = "github"
 
 	issues, err := d.fetchIssuesForProvider(context.Background(), "/test/repo", wfCfg)
@@ -75,7 +75,7 @@ func TestFetchIssuesForProvider_GitHub_CustomLabel(t *testing.T) {
 
 	d := testDaemonWithExec(cfg, mockExec)
 
-	wfCfg := workflow.DefaultConfig()
+	wfCfg := workflow.DefaultWorkflowConfig()
 	wfCfg.Source.Provider = "github"
 	wfCfg.Source.Filter.Label = "custom-label"
 
@@ -95,7 +95,7 @@ func TestFetchIssuesForProvider_UnknownProvider(t *testing.T) {
 	cfg := testConfig()
 	d := testDaemon(cfg)
 
-	wfCfg := workflow.DefaultConfig()
+	wfCfg := workflow.DefaultWorkflowConfig()
 	wfCfg.Source.Provider = "unknown_provider"
 
 	_, err := d.fetchIssuesForProvider(context.Background(), "/test/repo", wfCfg)

--- a/internal/manager/session_manager.go
+++ b/internal/manager/session_manager.go
@@ -153,13 +153,7 @@ func (sm *SessionManager) HasActiveStreaming() bool {
 
 // GetSession returns the session config for a given session ID.
 func (sm *SessionManager) GetSession(sessionID string) *config.Session {
-	sessions := sm.config.GetSessions()
-	for i := range sessions {
-		if sessions[i].ID == sessionID {
-			return &sessions[i]
-		}
-	}
-	return nil
+	return sm.config.GetSession(sessionID)
 }
 
 // Select prepares a session for activation, creating or reusing a runner,

--- a/internal/workflow/defaults.go
+++ b/internal/workflow/defaults.go
@@ -118,11 +118,6 @@ func DefaultWorkflowConfig() *Config {
 	}
 }
 
-// DefaultConfig returns the default config. Alias for DefaultWorkflowConfig.
-func DefaultConfig() *Config {
-	return DefaultWorkflowConfig()
-}
-
 // Merge overlays partial onto defaults. States present in partial replace the
 // corresponding default state entirely. States in defaults but not in partial
 // are preserved. Top-level fields (Workflow, Start) use partial if non-empty.

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -76,7 +76,7 @@ func LoadAndMerge(repoPath string) (*Config, error) {
 		return nil, err
 	}
 
-	defaults := DefaultConfig()
+	defaults := DefaultWorkflowConfig()
 	if cfg == nil {
 		return defaults, nil
 	}


### PR DESCRIPTION
## Summary
Clean up minor code indirections: remove the `DefaultConfig()` alias in favor of calling `DefaultWorkflowConfig()` directly, and delegate `SessionManager.GetSession` to the existing `config.GetSession` method instead of reimplementing the lookup.

## Changes
- Remove `workflow.DefaultConfig()` alias; all callers now use `workflow.DefaultWorkflowConfig()` directly
- Simplify `SessionManager.GetSession` to delegate to `config.GetSession(sessionID)` instead of manually iterating over sessions
- Update all references across daemon, CLI, and test files

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify no regressions
- Confirm no remaining references to the removed `DefaultConfig` function

Fixes #151