### PR TITLE
fix(test): skip permission-based tests when running as root

### DIFF
--- a/internal/manager/session_manager_test.go
+++ b/internal/manager/session_manager_test.go
@@ -833,6 +833,9 @@ func TestCopyClaudeSessionForFork_NoSessionFileCopyFallback(t *testing.T) {
 }
 
 func TestCopyClaudeSessionForFork_CleansUpOnFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, file permission restrictions are not enforced")
+	}
 	// Test that partial destination file is cleaned up when copy fails
 	// We test this by making the destination directory read-only after creating it,
 	// which will cause os.Create to fail
@@ -968,6 +971,9 @@ func TestSessionManager_SaveMessages_Success(t *testing.T) {
 }
 
 func TestSessionManager_SaveMessages_Error(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, file permission restrictions are not enforced")
+	}
 	// Set HOME to a read-only path to trigger a write error
 	tempDir := t.TempDir()
 	readOnlyDir := filepath.Join(tempDir, "readonly")
@@ -1030,6 +1036,9 @@ func TestSessionManager_SaveRunnerMessages_Success(t *testing.T) {
 }
 
 func TestSessionManager_SaveRunnerMessages_Error(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("skipping: running as root, file permission restrictions are not enforced")
+	}
 	// Set HOME to a read-only path to trigger a write error
 	tempDir := t.TempDir()
 	readOnlyDir := filepath.Join(tempDir, "readonly")


### PR DESCRIPTION
## Summary
Tests that rely on file permission restrictions (read-only directories causing write failures) don't work when running as root inside containers, since root bypasses filesystem permission checks. This adds skip guards to those tests.

## Changes
- Add `os.Getuid() == 0` checks to three tests in `session_manager_test.go` that depend on permission-denied errors:
  - `TestCopyClaudeSessionForFork_CleansUpOnFailure`
  - `TestSessionManager_SaveMessages_Error`
  - `TestSessionManager_SaveRunnerMessages_Error`

## Test plan
- Run `go test -p=1 -count=1 ./internal/manager/...` as a normal user — all three tests should execute and pass
- Run the same tests as root (e.g., in a Docker container) — the three tests should be skipped with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #153