### PR TITLE
fix(workflow): replace fmt.Sprintf comparison in valuesEqual with reflect.DeepEqual

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"time"
 )
 
@@ -300,14 +301,47 @@ func lookupVariable(key string, data map[string]any) (any, bool) {
 	return val, ok
 }
 
-// valuesEqual compares two values for equality, handling type coercion
-// between numeric types (int vs float64 from JSON unmarshaling).
+// valuesEqual compares two values for equality, handling numeric type coercion
+// between int and float64 (common when values come from JSON unmarshaling).
 func valuesEqual(a, b any) bool {
-	// Direct equality
-	if fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b) {
-		return true
+	af, aIsNum := toFloat64(a)
+	bf, bIsNum := toFloat64(b)
+	if aIsNum && bIsNum {
+		return af == bf
 	}
-	return false
+	return reflect.DeepEqual(a, b)
+}
+
+// toFloat64 converts numeric types to float64, returning false if v is not numeric.
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
+	}
 }
 
 // processPassState injects data into step data and immediately transitions to the next state.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1149,6 +1149,12 @@ func TestValuesEqual(t *testing.T) {
 		{"int match", 42, 42, true},
 		{"int vs float64", 42, float64(42), true},
 		{"int mismatch", 42, 43, false},
+		{"map equal", map[string]any{"a": 1}, map[string]any{"a": 1}, true},
+		{"map not equal", map[string]any{"a": 1}, map[string]any{"a": 2}, false},
+		{"bool vs string true", true, "true", false},
+		{"int vs string", 42, "42", false},
+		{"nil vs nil", nil, nil, true},
+		{"nil vs string", nil, "nil", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Fix `valuesEqual` to use proper type-aware comparison instead of string formatting, which could produce false positives for semantically different values (e.g., `true` == `"true"`, `nil` == `"nil"`).

## Changes
- Replace `fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)` with `reflect.DeepEqual` for general comparison
- Add `toFloat64` helper to handle numeric type coercion (int/float64 from JSON unmarshaling) as a special case
- Add test cases for maps, bool-vs-string, int-vs-string, and nil comparisons

## Test plan
- `go test -p=1 -count=1 ./internal/workflow/...`
- New test cases in `TestValuesEqual` verify that previously false-positive comparisons now correctly return false

Fixes #143