### PR TITLE
fix: await_review items no longer consume concurrency slots

### DIFF
--- a/internal/daemonstate/state.go
+++ b/internal/daemonstate/state.go
@@ -47,8 +47,13 @@ type WorkItem struct {
 
 // ConsumesSlot returns true if the work item currently consumes a concurrency slot.
 // This is true when the item has an active async worker (Phase == "async_pending"
-// or Phase == "addressing_feedback").
+// or Phase == "addressing_feedback"), UNLESS the item is in the await_review step.
+// Items awaiting review are "set aside" — they should never block new coding work
+// from starting, even while actively addressing PR feedback comments.
 func (item *WorkItem) ConsumesSlot() bool {
+	if item.CurrentStep == "await_review" {
+		return false
+	}
 	return item.Phase == "async_pending" || item.Phase == "addressing_feedback"
 }
 


### PR DESCRIPTION
## Summary
- `ConsumesSlot()` now returns `false` when `CurrentStep == "await_review"`, regardless of phase
- Items awaiting review are "set aside" and never block new coding work from starting, even while actively addressing PR feedback
- Previously, entering `addressing_feedback` phase during `await_review` would consume a concurrency slot, blocking new issues

## Test plan
- [x] Extended `TestWorkItemProperties/ConsumesSlot` to verify `await_review` items (all phases) don't consume a slot
- [x] Extended `TestDaemonState_ActiveSlotCount` to verify `addressing_feedback` in `await_review` doesn't count
- [x] Added `TestStartQueuedItems_AwaitReviewDoesNotBlockNewWork` end-to-end test
- [x] Full test suite passes (`go test -p=1 -count=1 ./...`)

Closes #158