### PR TITLE
feat: default retry for network-bound workflow actions

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -383,9 +383,15 @@ func (e *Engine) AdvanceAfterAsync(item *WorkItemView, success bool) (*StepResul
 // handleFailure processes a failure in a task state, checking retry and catch rules
 // before falling back to the error edge.
 func (e *Engine) handleFailure(item *WorkItemView, state *State, errStr string, data map[string]any) (*StepResult, error) {
+	// Use explicit retry config, or fall back to default for retryable actions
+	retryRules := state.Retry
+	if len(retryRules) == 0 {
+		retryRules = DefaultRetryForAction(state.Action)
+	}
+
 	// Check retry rules first
 	retryCount := getRetryCount(item.StepData)
-	for _, retry := range state.Retry {
+	for _, retry := range retryRules {
 		if !matchesErrors(errStr, retry.Errors) {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Adds automatic retry with exponential backoff (3 attempts, 15s/30s/60s delays) for all network-bound workflow actions (`github.*`, `git.rebase`, `asana.comment`, `linear.comment`)
- Engine fallback in `handleFailure()` applies default retry when a state has no explicit retry config and the action is retryable — covers user-defined states automatically
- Explicit retry configs on `open_pr`, `push_ci_fix`, `rebase`, `merge` default states for documentation/visibility
- Fixes `Merge()` to deep-copy `Retry` and `Catch` slices (previously shared `*Duration` pointer across configs)

Closes #158

## Test plan
- [x] `TestDefaultRetryForAction` — table-driven covering all 12 retryable + 5 non-retryable actions
- [x] `TestDefaultRetryConfig` — verifies 3 attempts, 15s interval, 2.0x backoff
- [x] `TestEngine_ProcessStep_DefaultRetryOnNetworkAction` — github.create_pr auto-retries without explicit config
- [x] `TestEngine_ProcessStep_NoDefaultRetryOnAICode` — ai.code goes straight to error edge
- [x] `TestEngine_ProcessStep_ExplicitRetryOverridesDefault` — explicit max_attempts=5 used instead of default 3
- [x] `TestEngine_ProcessStep_DefaultRetryExhaustedFallsToErrorEdge` — after 3 default retries, follows error edge
- [x] `TestDefaultWorkflowConfig_RetryOnNetworkStates` — default states have retry where expected
- [x] Deep-copy tests for Retry (interval pointer) and Catch (errors slice) in Merge()
- [x] Full test suite passes: `go test -p=1 -count=1 ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)