### PR TITLE
fix: make notification goroutine in createWorkerWithPrompt cancellable

### DIFF
--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -917,11 +917,14 @@ func (d *Daemon) createWorkerWithPrompt(ctx context.Context, item *daemonstate.W
 	d.mu.Unlock()
 
 	go func() {
-		w.Wait()
 		select {
+		case <-w.DoneChan():
+			select {
+			case <-ctx.Done():
+			default:
+				d.notifyWorkerDone()
+			}
 		case <-ctx.Done():
-		default:
-			d.notifyWorkerDone()
 		}
 	}()
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -146,6 +146,13 @@ func (w *SessionWorker) Done() bool {
 	}
 }
 
+// DoneChan returns the channel that is closed when the worker finishes.
+// Callers can select on this alongside other channels (e.g. ctx.Done())
+// to avoid blocking indefinitely if the worker never completes.
+func (w *SessionWorker) DoneChan() <-chan struct{} {
+	return w.done
+}
+
 // run is the main worker loop.
 func (w *SessionWorker) run() {
 	defer w.once.Do(func() { close(w.done) })


### PR DESCRIPTION
## Summary
Fix a potential goroutine leak in `createWorkerWithPrompt` where the notification goroutine could block indefinitely if the worker never completes, even after the context is cancelled.

## Changes
- Add `DoneChan()` method to `SessionWorker` that exposes the done channel for select-based waiting
- Replace blocking `w.Wait()` call with a select on both `w.DoneChan()` and `ctx.Done()`, so the goroutine exits promptly on context cancellation
- Suppress `notifyWorkerDone` when the context is already cancelled to avoid spurious notifications
- Add tests for `DoneChan` behavior (closed when done, blocks while running)
- Add test verifying that a cancelled context suppresses the worker-done notification

## Test plan
- `go test -p=1 -count=1 ./internal/worker/...` — validates `DoneChan` returns a closed channel for done workers and an open channel for running workers
- `go test -p=1 -count=1 ./internal/daemon/...` — validates the cancellable goroutine pattern and that cancelled contexts suppress notifications
- `go test -p=1 -count=1 ./...` — full suite passes

Fixes #145