### PR TITLE
fix: eliminate data race on stderrContent read after mutex unlock

### DIFF
--- a/internal/claude/process_manager.go
+++ b/internal/claude/process_manager.go
@@ -777,8 +777,9 @@ func (pm *ProcessManager) drainStderr() {
 		if len(stderrBytes) > 0 {
 			pm.mu.Lock()
 			pm.stderrContent = strings.TrimSpace(string(stderrBytes))
+			content := pm.stderrContent
 			pm.mu.Unlock()
-			pm.log.Debug("captured stderr", "content", pm.stderrContent)
+			pm.log.Debug("captured stderr", "content", content)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Fix a data race in `ProcessManager.drainStderr()` where `stderrContent` was read outside the mutex-protected section for debug logging.

## Changes
- Copy `stderrContent` to a local variable while still holding the mutex
- Use the local copy for the subsequent debug log call, avoiding an unprotected read after `mu.Unlock()`

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify no regressions
- Run `go test -race ./internal/claude/...` to confirm the data race is resolved

Fixes #147