### PR TITLE
fix(daemonstate): only increment ErrorCount when setting a non-empty error message

### DIFF
--- a/internal/daemonstate/state.go
+++ b/internal/daemonstate/state.go
@@ -328,13 +328,16 @@ func (s *DaemonState) UpdateWorkItem(id string, fn func(*WorkItem)) {
 }
 
 // SetErrorMessage sets the error message on a work item and increments the error count.
+// ErrorCount is only incremented when msg is non-empty; passing "" clears the message without affecting the count.
 func (s *DaemonState) SetErrorMessage(id, msg string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if item, ok := s.WorkItems[id]; ok {
 		item.ErrorMessage = msg
-		item.ErrorCount++
+		if msg != "" {
+			item.ErrorCount++
+		}
 		item.UpdatedAt = time.Now()
 	}
 }

--- a/internal/daemonstate/state_test.go
+++ b/internal/daemonstate/state_test.go
@@ -350,6 +350,16 @@ func TestDaemonState_SetErrorMessage(t *testing.T) {
 		t.Errorf("expected error count 2, got %d", item.ErrorCount)
 	}
 
+	// Clearing with empty string should not increment ErrorCount
+	state.SetErrorMessage("item-1", "")
+	item = state.GetWorkItem("item-1")
+	if item.ErrorMessage != "" {
+		t.Errorf("expected empty error message after clear, got %q", item.ErrorMessage)
+	}
+	if item.ErrorCount != 2 {
+		t.Errorf("expected error count to remain 2 after clearing, got %d", item.ErrorCount)
+	}
+
 	// No-op for nonexistent item
 	state.SetErrorMessage("nonexistent", "error")
 }


### PR DESCRIPTION
## Summary
Fixes `SetErrorMessage` so that clearing an error (passing `""`) no longer incorrectly inflates the `ErrorCount`. Previously, every call to `SetErrorMessage` incremented the count, even when the intent was to clear a transient error.

## Changes
- Guard `ErrorCount++` behind a `msg != ""` check in `SetErrorMessage`
- Update doc comment to clarify the clearing semantics
- Add regression test verifying that clearing with `""` leaves `ErrorCount` unchanged

## Test plan
- `go test -p=1 -count=1 ./internal/daemonstate/...` — new test case asserts count stays at 2 after a clear

Fixes #141