### PR TITLE
fix: use GetAllWorkItems() in recovery to respect DaemonState locking contract

### DIFF
--- a/internal/daemon/recovery.go
+++ b/internal/daemon/recovery.go
@@ -19,7 +19,7 @@ import (
 func (d *Daemon) reconstructSessions() {
 	log := d.logger.With("component", "recovery")
 
-	for _, item := range d.state.WorkItems {
+	for _, item := range d.state.GetAllWorkItems() {
 		if item.IsTerminal() {
 			continue
 		}
@@ -61,17 +61,22 @@ func (d *Daemon) reconstructSessions() {
 
 // recoverFromState reconciles daemon state with reality after a restart.
 func (d *Daemon) recoverFromState(ctx context.Context) {
-	if d.state == nil || len(d.state.WorkItems) == 0 {
+	if d.state == nil {
 		return
 	}
 
 	// Reconstruct sessions before recovery so GetSession() works for all items.
 	d.reconstructSessions()
 
-	log := d.logger.With("component", "recovery")
-	log.Info("recovering from previous state", "workItems", len(d.state.WorkItems))
+	items := d.state.GetAllWorkItems()
+	if len(items) == 0 {
+		return
+	}
 
-	for _, item := range d.state.WorkItems {
+	log := d.logger.With("component", "recovery")
+	log.Info("recovering from previous state", "workItems", len(items))
+
+	for _, item := range items {
 		if item.IsTerminal() {
 			continue
 		}

--- a/internal/daemonstate/state.go
+++ b/internal/daemonstate/state.go
@@ -261,6 +261,21 @@ func (s *DaemonState) GetWorkItemsByState(state WorkItemState) []*WorkItem {
 	return items
 }
 
+// GetAllWorkItems returns a snapshot of all work items regardless of state.
+// Callers receive a slice of pointers; the slice itself is safe to iterate
+// without holding the lock, but individual WorkItem fields must not be
+// modified outside of the provided mutation helpers (UpdateWorkItem, etc.).
+func (s *DaemonState) GetAllWorkItems() []*WorkItem {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := make([]*WorkItem, 0, len(s.WorkItems))
+	for _, item := range s.WorkItems {
+		items = append(items, item)
+	}
+	return items
+}
+
 // GetActiveWorkItems returns all non-terminal, non-queued work items.
 func (s *DaemonState) GetActiveWorkItems() []*WorkItem {
 	s.mu.RLock()


### PR DESCRIPTION
## Summary
Recovery code was directly accessing `d.state.WorkItems` map without holding the mutex lock, violating the DaemonState locking contract. This replaces direct map access with the new `GetAllWorkItems()` method that properly acquires a read lock.

## Changes
- Add `GetAllWorkItems()` method to `DaemonState` that returns a snapshot of all work items under a read lock
- Replace direct `d.state.WorkItems` map access in `reconstructSessions()` and `recoverFromState()` with `GetAllWorkItems()`
- Add tests for `GetAllWorkItems()` covering empty state, mixed item states, and slice independence from the internal map

## Test plan
- `go test -p=1 -count=1 ./internal/daemonstate/...` — verifies the new `GetAllWorkItems()` method
- `go test -p=1 -count=1 ./internal/daemon/...` — verifies recovery still works with the new accessor
- `go test -p=1 -count=1 ./...` — full suite passes

Fixes #139