### PR TITLE
feat(daemon): add slack.notify action for webhook notifications

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -825,6 +825,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("ai.resolve_conflicts", &resolveConflictsAction{daemon: d})
 	registry.Register("asana.comment", &asanaCommentAction{daemon: d})
 	registry.Register("linear.comment", &linearCommentAction{daemon: d})
+	registry.Register("slack.notify", &slackNotifyAction{daemon: d})
 	return registry
 }
 


### PR DESCRIPTION
## Summary
Adds a new `slack.notify` workflow action that posts notifications to Slack via incoming webhooks, enabling workflow-driven Slack alerts for work item lifecycle events.

## Changes
- Add `slackNotifyAction` struct implementing the workflow action interface
- Add `sendSlackNotification` method on `Daemon` that handles webhook URL resolution, Go `text/template` message rendering, and HTTP POST to Slack
- Support `$ENV_VAR` syntax in `webhook_url` for secret injection without hardcoding credentials in config
- Template variables available: `.Title`, `.IssueID`, `.IssueURL`, `.PRURL`, `.Branch`, `.Status`
- Optional params: `username` (default "erg"), `icon_emoji` (default ":robot_face:"), `channel` (webhook default)
- Register `slack.notify` in the daemon's action registry
- Add comprehensive tests: missing work item, missing required params, invalid template, env var resolution, all template variables, default values, Slack error handling, and registry registration

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify all new and existing tests pass
- Tests use `httptest.Server` to simulate Slack webhook responses without external dependencies
- Validate error paths: missing webhook URL, missing message, invalid template syntax, Slack returning non-200
- Validate happy paths: env var expansion for webhook URL, template variable substitution, default username/emoji

Fixes #186