### PR TITLE
feat(workflow): add gate.approved event for external approval gates

### DIFF
--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -186,9 +186,10 @@ func DefaultRetryForAction(action string) []RetryConfig {
 
 // ValidEvents is the set of recognized event names for wait states.
 var ValidEvents = map[string]bool{
-	"pr.reviewed":  true,
-	"ci.complete":  true,
-	"pr.mergeable": true,
+	"pr.reviewed":   true,
+	"ci.complete":   true,
+	"pr.mergeable":  true,
+	"gate.approved": true,
 }
 
 // ValidStateTypes is the set of recognized state types.


### PR DESCRIPTION
## Summary
Adds a new `gate.approved` workflow event that pauses execution until a human provides an explicit approval signal on the associated GitHub issue. This enables workflow authors to insert manual approval checkpoints between automated steps.

## Changes
- Add `gate.approved` to the valid events registry in `internal/workflow/config.go`
- Implement `checkGateApproved` event checker in `internal/daemon/events.go` with two trigger modes:
  - `label_added` (default): fires when a configured label (default `approved`) is present on the issue
  - `comment_match`: fires when a comment matching a regex pattern is posted after the gate step was entered
- Add `CheckIssueHasLabel` and `GetIssueComments` methods to `GitService` in `internal/git/github.go`
- Add comprehensive tests covering both trigger modes, edge cases (non-GitHub issues, invalid issue numbers, CLI errors, invalid regex, unknown triggers, missing patterns), and the new git service methods

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all new and existing tests pass
- New tests cover: label present/absent, comment match/no-match/old-comment-ignored, non-GitHub issues, missing work items, invalid issue numbers, CLI errors, invalid regex patterns, unknown trigger types, default trigger behavior, missing comment patterns, and git service label/comment methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #189