### PR TITLE
feat(daemon): add ai.address_review action for PR feedback

### DIFF
--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -331,7 +331,7 @@ func TestPrimaryWorkflowPath_Default(t *testing.T) {
 	cfg := workflow.DefaultWorkflowConfig()
 	path := primaryWorkflowPath(cfg)
 
-	// Default happy path: coding → open_pr → await_ci → check_ci_result → await_review → merge → done
+	// Default happy path: coding → open_pr → await_ci → check_ci_result → await_review → check_review_result → merge → done
 	expectedStart := "coding"
 	if len(path) == 0 || path[0] != expectedStart {
 		t.Errorf("expected path to start with %q, got %v", expectedStart, path)
@@ -348,7 +348,8 @@ func TestPrimaryWorkflowPath_Default(t *testing.T) {
 		{"open_pr", "await_ci"},
 		{"await_ci", "check_ci_result"},
 		{"check_ci_result", "await_review"},
-		{"await_review", "merge"},
+		{"await_review", "check_review_result"},
+		{"check_review_result", "merge"},
 		{"merge", "done"},
 	}
 	for _, c := range checkOrder {
@@ -442,7 +443,7 @@ func TestPrintMapView_DefaultConfig(t *testing.T) {
 	out := buf.String()
 
 	// All primary path states should appear
-	for _, state := range []string{"coding", "open_pr", "await_ci", "await_review", "merge", "done"} {
+	for _, state := range []string{"coding", "open_pr", "await_ci", "await_review", "check_review_result", "merge", "done"} {
 		if !strings.Contains(out, state) {
 			t.Errorf("expected state %q in map output: %q", state, out)
 		}

--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -1806,6 +1806,146 @@ func getCIFixRounds(stepData map[string]any) int {
 	}
 }
 
+// addressReviewAction implements the ai.address_review action.
+type addressReviewAction struct {
+	daemon *Daemon
+}
+
+// Execute fetches PR review comments and resumes the coding session to address them.
+func (a *addressReviewAction) Execute(ctx context.Context, ac *workflow.ActionContext) workflow.ActionResult {
+	d := a.daemon
+	item, ok := d.state.GetWorkItem(ac.WorkItemID)
+	if !ok {
+		return workflow.ActionResult{Error: fmt.Errorf("work item not found: %s", ac.WorkItemID)}
+	}
+
+	// Check max rounds
+	maxRounds := ac.Params.Int("max_review_rounds", 3)
+	rounds := getReviewRounds(item.StepData)
+	if rounds >= maxRounds {
+		return workflow.ActionResult{Error: fmt.Errorf("max review rounds exceeded (%d/%d)", rounds, maxRounds)}
+	}
+
+	sess := d.config.GetSession(item.SessionID)
+	if sess == nil {
+		return workflow.ActionResult{Error: fmt.Errorf("session not found")}
+	}
+
+	// Fetch review comments
+	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	comments, err := d.gitService.FetchPRReviewComments(pollCtx, sess.RepoPath, item.Branch)
+	if err != nil {
+		d.logger.Warn("failed to fetch review comments, proceeding with generic message", "error", err)
+	}
+
+	// Filter out daemon transcript comments
+	reviewComments := worker.FilterTranscriptComments(comments)
+
+	// Increment rounds
+	d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
+		it.StepData["review_rounds"] = rounds + 1
+		it.UpdatedAt = time.Now()
+	})
+
+	// Resume session
+	if err := d.startAddressReview(ctx, item, sess, rounds+1, reviewComments); err != nil {
+		return workflow.ActionResult{Error: err}
+	}
+
+	return workflow.ActionResult{Success: true, Async: true}
+}
+
+// startAddressReview resumes the coding session with PR review feedback context.
+func (d *Daemon) startAddressReview(ctx context.Context, item daemonstate.WorkItem, sess *config.Session, round int, comments []git.PRReviewComment) error {
+	// Refresh stale session (handles daemon restarts where old session is gone)
+	sess = d.refreshStaleSession(ctx, item, sess)
+
+	var prompt string
+	if len(comments) > 0 {
+		prompt = worker.FormatPRCommentsPrompt(comments)
+	} else {
+		prompt = formatAddressReviewPrompt(round)
+	}
+
+	// Resolve system prompt and format_command from workflow config's address_review state.
+	wfCfg := d.getWorkflowConfig(sess.RepoPath)
+	reviewState := wfCfg.States["address_review"]
+	systemPrompt := ""
+	formatCommand := ""
+	if reviewState != nil {
+		p := workflow.NewParamHelper(reviewState.Params)
+		systemPrompt = p.String("system_prompt", "")
+		formatCommand = p.String("format_command", "")
+		if formatCommand != "" {
+			// address_review has its own format_command — update step data so
+			// handleAsyncComplete uses it as the formatter safety net after
+			// this round completes.
+			formatMessage := p.String("format_message", "Apply auto-formatting")
+			d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
+				it.StepData["_format_command"] = formatCommand
+				it.StepData["_format_message"] = formatMessage
+			})
+			d.saveState()
+		}
+	}
+
+	resolvedPrompt, err := workflow.ResolveSystemPrompt(systemPrompt, sess.RepoPath)
+	if err != nil {
+		d.logger.Warn("failed to resolve address_review system prompt", "error", err)
+	}
+
+	if resolvedPrompt == "" {
+		resolvedPrompt = DefaultCodingSystemPrompt
+	}
+
+	// Inject formatting instructions if a format command is configured.
+	// If address_review has no format_command param, fall back to whatever the
+	// coding step stored in step data.
+	if formatCommand == "" {
+		formatCommand, _ = item.StepData["_format_command"].(string)
+	}
+	if formatCommand != "" {
+		resolvedPrompt = resolvedPrompt + "\n\nFORMATTING: Before committing any changes, run the following formatter command:\n  " + formatCommand + "\nStage and include all formatting changes in your commit."
+	}
+
+	d.startWorkerWithPrompt(ctx, item, sess, prompt, resolvedPrompt)
+	d.logger.Info("started address review session", "workItem", item.ID, "round", round, "commentCount", len(comments))
+	return nil
+}
+
+// formatAddressReviewPrompt formats a fallback prompt for Claude when review comments are unavailable.
+func formatAddressReviewPrompt(round int) string {
+	return fmt.Sprintf(`PR REVIEW — ADDRESS ROUND %d
+
+The PR has received review feedback requesting changes. Please review the PR comments and make the requested changes.
+
+INSTRUCTIONS:
+1. Review all open comments on this PR carefully
+2. Make the requested changes to address the feedback
+3. Run relevant tests locally to verify your changes
+4. Commit your changes locally — the system will push and re-request review automatically
+
+DO NOT push or create PRs — the system handles this.`, round)
+}
+
+// getReviewRounds extracts the review round counter from step data.
+func getReviewRounds(stepData map[string]any) int {
+	v, ok := stepData["review_rounds"]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case int:
+		return n
+	case float64:
+		return int(n)
+	default:
+		return 0
+	}
+}
+
 // saveRunnerMessages saves messages for a session's runner.
 func (d *Daemon) saveRunnerMessages(sessionID string, runner claude.RunnerInterface) {
 	if err := d.sessionMgr.SaveRunnerMessages(sessionID, runner); err != nil {

--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -4178,6 +4178,320 @@ func TestLinearCommentAction_ProviderError(t *testing.T) {
 	}
 }
 
+// --- addressReviewAction tests ---
+
+func TestAddressReviewAction_Execute_WorkItemNotFound(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	action := &addressReviewAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"max_review_rounds": 3})
+	ac := &workflow.ActionContext{
+		WorkItemID: "nonexistent",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure for missing work item")
+	}
+	if result.Error == nil {
+		t.Error("expected error for missing work item")
+	}
+}
+
+func TestAddressReviewAction_Execute_MaxRoundsExceeded(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		StepData:  map[string]any{"review_rounds": 3},
+	})
+
+	action := &addressReviewAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"max_review_rounds": 3})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure when max rounds exceeded")
+	}
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "max review rounds exceeded") {
+		t.Errorf("expected 'max review rounds exceeded' error, got: %v", result.Error)
+	}
+}
+
+func TestAddressReviewAction_Execute_MaxRoundsFloat64(t *testing.T) {
+	// JSON deserialization produces float64 for numbers
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		StepData:  map[string]any{"review_rounds": float64(3)},
+	})
+
+	action := &addressReviewAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"max_review_rounds": 3})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected error when max rounds exceeded (float64)")
+	}
+}
+
+func TestAddressReviewAction_Execute_NoSession(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:       "item-1",
+		IssueRef: config.IssueRef{Source: "github", ID: "42"},
+		Branch:   "feature-1",
+		StepData: map[string]any{},
+	})
+
+	action := &addressReviewAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"max_review_rounds": 3})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure when session not found")
+	}
+	if result.Error == nil {
+		t.Error("expected error when session not found")
+	}
+}
+
+func TestGetReviewRounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		stepData map[string]any
+		want     int
+	}{
+		{"missing", map[string]any{}, 0},
+		{"int zero", map[string]any{"review_rounds": 0}, 0},
+		{"int one", map[string]any{"review_rounds": 1}, 1},
+		{"int three", map[string]any{"review_rounds": 3}, 3},
+		{"float64 zero", map[string]any{"review_rounds": float64(0)}, 0},
+		{"float64 two", map[string]any{"review_rounds": float64(2)}, 2},
+		{"wrong type", map[string]any{"review_rounds": "oops"}, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getReviewRounds(tc.stepData)
+			if got != tc.want {
+				t.Errorf("getReviewRounds(%v) = %d, want %d", tc.stepData, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatAddressReviewPrompt(t *testing.T) {
+	prompt := formatAddressReviewPrompt(2)
+	if !strings.Contains(prompt, "ROUND 2") {
+		t.Error("expected prompt to contain round number")
+	}
+	if !strings.Contains(prompt, "DO NOT push") {
+		t.Error("expected prompt to contain DO NOT push instruction")
+	}
+}
+
+// --- startAddressReview format_command tests ---
+
+// testAddressReviewJSON is a minimal CHANGES_REQUESTED review that passes
+// FilterTranscriptComments so startAddressReview reaches the format_command logic.
+const testAddressReviewJSON = `{"reviews":[{"author":{"login":"reviewer1"},"body":"Please fix the issue","state":"CHANGES_REQUESTED","comments":[]}],"comments":[]}`
+
+// TestStartAddressReview_FormatCommandStoredInStepData verifies that when the
+// address_review workflow state has a format_command param, it is stored in
+// item.StepData.
+func TestStartAddressReview_FormatCommandStoredInStepData(t *testing.T) {
+	cfg := testConfig()
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d := testDaemon(cfg)
+	d.workflowConfigs = map[string]*workflow.Config{
+		"/test/repo": {
+			States: map[string]*workflow.State{
+				"address_review": {
+					Params: map[string]any{
+						"format_command": "gofmt -l -w .",
+						"format_message": "style: gofmt",
+					},
+				},
+			},
+		},
+	}
+
+	item := &daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		StepData:  map[string]any{},
+	}
+	d.state.AddWorkItem(item)
+
+	comments := worker.FilterTranscriptComments([]git.PRReviewComment{
+		{Author: "reviewer1", Body: "Please fix the issue"},
+	})
+	_ = d.startAddressReview(context.Background(), *item, sess, 1, comments)
+
+	updatedItem, _ := d.state.GetWorkItem(item.ID)
+	if got, _ := updatedItem.StepData["_format_command"].(string); got != "gofmt -l -w ." {
+		t.Errorf("expected _format_command=%q, got %q", "gofmt -l -w .", got)
+	}
+	if got, _ := updatedItem.StepData["_format_message"].(string); got != "style: gofmt" {
+		t.Errorf("expected _format_message=%q, got %q", "style: gofmt", got)
+	}
+}
+
+// TestStartAddressReview_FormatCommandDefaultMessage verifies that when address_review has
+// format_command but no format_message, the default message is used.
+func TestStartAddressReview_FormatCommandDefaultMessage(t *testing.T) {
+	cfg := testConfig()
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d := testDaemon(cfg)
+	d.workflowConfigs = map[string]*workflow.Config{
+		"/test/repo": {
+			States: map[string]*workflow.State{
+				"address_review": {
+					Params: map[string]any{
+						"format_command": "gofmt -l -w .",
+						// no format_message
+					},
+				},
+			},
+		},
+	}
+
+	item := &daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		StepData:  map[string]any{},
+	}
+	d.state.AddWorkItem(item)
+
+	_ = d.startAddressReview(context.Background(), *item, sess, 1, nil)
+
+	updatedItem, _ := d.state.GetWorkItem(item.ID)
+	if got, _ := updatedItem.StepData["_format_command"].(string); got != "gofmt -l -w ." {
+		t.Errorf("expected _format_command=%q, got %q", "gofmt -l -w .", got)
+	}
+	if got, _ := updatedItem.StepData["_format_message"].(string); got != "Apply auto-formatting" {
+		t.Errorf("expected default _format_message=%q, got %q", "Apply auto-formatting", got)
+	}
+}
+
+// TestStartAddressReview_InheritsFormatCommandFromStepData verifies that when
+// address_review has no format_command param, the existing _format_command in
+// step data (from the coding step) is preserved.
+func TestStartAddressReview_InheritsFormatCommandFromStepData(t *testing.T) {
+	cfg := testConfig()
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d := testDaemon(cfg)
+	// Use default workflow config — address_review state has no format_command param.
+
+	item := &daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		// _format_command already set by the coding step.
+		StepData: map[string]any{
+			"_format_command": "gofmt ./...",
+			"_format_message": "style: format",
+		},
+	}
+	d.state.AddWorkItem(item)
+
+	_ = d.startAddressReview(context.Background(), *item, sess, 1, nil)
+
+	// Existing _format_command must not be cleared.
+	updatedItem, _ := d.state.GetWorkItem(item.ID)
+	if got, _ := updatedItem.StepData["_format_command"].(string); got != "gofmt ./..." {
+		t.Errorf("expected _format_command=%q, got %q", "gofmt ./...", got)
+	}
+}
+
+// TestStartAddressReview_FormatCommandOverridesStepData verifies that an
+// address_review-specific format_command replaces whatever the coding step stored.
+func TestStartAddressReview_FormatCommandOverridesStepData(t *testing.T) {
+	cfg := testConfig()
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d := testDaemon(cfg)
+	d.workflowConfigs = map[string]*workflow.Config{
+		"/test/repo": {
+			States: map[string]*workflow.State{
+				"address_review": {
+					Params: map[string]any{
+						"format_command": "prettier --write .",
+						"format_message": "style: prettier",
+					},
+				},
+			},
+		},
+	}
+
+	item := &daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		StepData: map[string]any{
+			"_format_command": "gofmt ./...",
+			"_format_message": "style: gofmt",
+		},
+	}
+	d.state.AddWorkItem(item)
+
+	_ = d.startAddressReview(context.Background(), *item, sess, 1, nil)
+
+	updatedItem, _ := d.state.GetWorkItem(item.ID)
+	if got, _ := updatedItem.StepData["_format_command"].(string); got != "prettier --write ." {
+		t.Errorf("expected _format_command=%q, got %q", "prettier --write .", got)
+	}
+	if got, _ := updatedItem.StepData["_format_message"].(string); got != "style: prettier" {
+		t.Errorf("expected _format_message=%q, got %q", "style: prettier", got)
+	}
+}
+
 func TestLinearCommentAction_NoProvider(t *testing.T) {
 	cfg := testConfig()
 	// Registry with no Linear provider registered.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -820,6 +820,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("github.close_issue", &closeIssueAction{daemon: d})
 	registry.Register("github.request_review", &requestReviewAction{daemon: d})
 	registry.Register("ai.fix_ci", &fixCIAction{daemon: d})
+	registry.Register("ai.address_review", &addressReviewAction{daemon: d})
 	registry.Register("git.format", &formatAction{daemon: d})
 	registry.Register("git.rebase", &rebaseAction{daemon: d})
 	registry.Register("ai.resolve_conflicts", &resolveConflictsAction{daemon: d})

--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -85,39 +85,36 @@ func (c *EventChecker) checkPRReviewed(ctx context.Context, params *workflow.Par
 		return false, nil, nil
 	}
 
+	autoAddress := params.Bool("auto_address", true)
+
 	if result.CommentCount > item.CommentsAddressed {
 		log.Debug("new comments detected, checking for review feedback",
 			"addressed", item.CommentsAddressed,
 			"current", result.CommentCount,
 		)
 
-		autoAddress := params.Bool("auto_address", true)
-		maxRounds := params.Int("max_feedback_rounds", 3)
+		if autoAddress {
+			maxRounds := params.Int("max_feedback_rounds", 3)
+			if item.FeedbackRounds >= maxRounds {
+				log.Warn("max feedback rounds reached",
+					"rounds", item.FeedbackRounds,
+					"max", maxRounds,
+				)
+				return false, nil, nil
+			}
 
-		if !autoAddress {
-			log.Debug("auto_address disabled, skipping feedback")
+			// Check concurrency before starting feedback
+			if d.activeSlotCount() >= d.getMaxConcurrent() {
+				log.Debug("no concurrency slot available for feedback, deferring")
+				return false, nil, nil
+			}
+
+			// Start addressing feedback (this is an internal sub-action of the wait state).
+			// Pass the batch CommentCount so addressFeedback sets CommentsAddressed
+			// using the same counting source used for detection here.
+			d.addressFeedback(ctx, workItem, result.CommentCount)
 			return false, nil, nil
 		}
-
-		if item.FeedbackRounds >= maxRounds {
-			log.Warn("max feedback rounds reached",
-				"rounds", item.FeedbackRounds,
-				"max", maxRounds,
-			)
-			return false, nil, nil
-		}
-
-		// Check concurrency before starting feedback
-		if d.activeSlotCount() >= d.getMaxConcurrent() {
-			log.Debug("no concurrency slot available for feedback, deferring")
-			return false, nil, nil
-		}
-
-		// Start addressing feedback (this is an internal sub-action of the wait state).
-		// Pass the batch CommentCount so addressFeedback sets CommentsAddressed
-		// using the same counting source used for detection here.
-		d.addressFeedback(ctx, workItem, result.CommentCount)
-		return false, nil, nil
 	}
 
 	// Check review decision
@@ -130,6 +127,13 @@ func (c *EventChecker) checkPRReviewed(ctx context.Context, params *workflow.Par
 	if reviewDecision == git.ReviewApproved {
 		log.Info("PR approved")
 		return true, map[string]any{"review_approved": true}, nil
+	}
+
+	// When auto_address is disabled, fire the event for changes_requested so
+	// the workflow engine can route to an explicit address_review state.
+	if !autoAddress && reviewDecision == git.ReviewChangesRequested {
+		log.Info("PR has changes requested, advancing for address_review")
+		return true, map[string]any{"changes_requested": true}, nil
 	}
 
 	return false, nil, nil

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -140,6 +140,7 @@ var ValidActions = map[string]bool{
 	"github.request_review": true,
 	"ai.fix_ci":             true,
 	"ai.resolve_conflicts":  true,
+	"ai.address_review":     true,
 	"git.format":            true,
 	"git.rebase":            true,
 	"asana.comment":         true,


### PR DESCRIPTION
## Summary
Adds an explicit `ai.address_review` workflow action that fetches PR review comments and resumes the coding session to address reviewer feedback, replacing the inline `addressFeedback` approach with a proper workflow state machine path.

## Changes
- Add `addressReviewAction` in `internal/daemon/actions.go` that fetches PR review comments, tracks review rounds, and resumes the session with formatted feedback context
- Register `ai.address_review` in the action registry and valid actions list
- Refactor `checkPRReviewed` event logic: when `auto_address=false`, fire a `changes_requested` event instead of handling feedback inline, enabling the workflow engine to route through explicit states
- Update default workflow config to add `check_review_result` (choice), `address_review` (task), and `push_review_fix` (task) states, creating the loop: `await_review → check_review_result → address_review → push_review_fix → await_review`
- Support `format_command`/`format_message` params on the `address_review` state, with fallback to coding step's stored format command
- Default workflow now uses `auto_address: false` with explicit state routing instead of `auto_address: true` with inline feedback

## Test plan
- Unit tests for `addressReviewAction.Execute`: work item not found, max rounds exceeded, float64 round count, missing session
- Table-driven tests for `getReviewRounds` helper covering int, float64, missing, and invalid types
- Tests for `formatAddressReviewPrompt` output
- Tests for `startAddressReview` format_command behavior: stored in step data, default message fallback, inheritance from coding step, and override scenarios
- Event tests for `checkPRReviewed`: `changes_requested` fires when `auto_address=false`, does not fire when `auto_address=true`
- Updated default workflow config tests validating the new state machine path
- Run `go test -p=1 -count=1 ./...`

Fixes #178