### PR TITLE
refactor(worker): decouple worker from manager via Host interface

### DIFF
--- a/internal/daemon/host.go
+++ b/internal/daemon/host.go
@@ -6,12 +6,11 @@ import (
 	"log/slog"
 
 	"github.com/zhubert/erg/internal/agentconfig"
+	"github.com/zhubert/erg/internal/claude"
 	"github.com/zhubert/erg/internal/daemonstate"
+	"github.com/zhubert/erg/internal/git"
 	"github.com/zhubert/erg/internal/worker"
 	"github.com/zhubert/erg/internal/workflow"
-	"github.com/zhubert/erg/internal/claude"
-	"github.com/zhubert/erg/internal/git"
-	"github.com/zhubert/erg/internal/manager"
 )
 
 // Compile-time assertion: Daemon must implement worker.Host.
@@ -19,10 +18,17 @@ var _ worker.Host = (*Daemon)(nil)
 
 // --- Host interface implementation ---
 
-func (d *Daemon) Config() agentconfig.Config             { return d.config }
-func (d *Daemon) GitService() *git.GitService            { return d.gitService }
-func (d *Daemon) SessionManager() *manager.SessionManager { return d.sessionMgr }
-func (d *Daemon) Logger() *slog.Logger                   { return d.logger }
+func (d *Daemon) Config() agentconfig.Config  { return d.config }
+func (d *Daemon) GitService() *git.GitService { return d.gitService }
+func (d *Daemon) Logger() *slog.Logger        { return d.logger }
+
+func (d *Daemon) GetPendingMessage(sessionID string) string {
+	return d.sessionMgr.StateManager().GetPendingMessage(sessionID)
+}
+
+func (d *Daemon) SetPendingMessage(sessionID, msg string) {
+	d.sessionMgr.StateManager().GetOrCreate(sessionID).SetPendingMsg(msg)
+}
 func (d *Daemon) MaxTurns() int                          { return d.getMaxTurns() }
 func (d *Daemon) MaxDuration() int                       { return d.getMaxDuration() }
 func (d *Daemon) AutoMerge() bool                        { return d.autoMerge }

--- a/internal/worker/host.go
+++ b/internal/worker/host.go
@@ -7,7 +7,6 @@ import (
 	"github.com/zhubert/erg/internal/agentconfig"
 	"github.com/zhubert/erg/internal/claude"
 	"github.com/zhubert/erg/internal/git"
-	"github.com/zhubert/erg/internal/manager"
 )
 
 // Host is the interface that SessionWorker uses to access its owning daemon.
@@ -19,8 +18,12 @@ type Host interface {
 	// GitService returns the git service.
 	GitService() *git.GitService
 
-	// SessionManager returns the session manager.
-	SessionManager() *manager.SessionManager
+	// GetPendingMessage returns and clears the pending message for a session.
+	// This is a consuming get — the message is cleared after retrieval.
+	GetPendingMessage(sessionID string) string
+
+	// SetPendingMessage queues a message to be sent to a session on its next turn.
+	SetPendingMessage(sessionID, msg string)
 
 	// Logger returns the structured logger.
 	Logger() *slog.Logger

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -191,7 +191,7 @@ func (w *SessionWorker) run() {
 		}
 
 		// Check for pending messages (e.g., child completion notifications)
-		pendingMsg := w.host.SessionManager().StateManager().GetPendingMessage(w.sessionID)
+		pendingMsg := w.host.GetPendingMessage(w.sessionID)
 		if pendingMsg != "" {
 			log.Debug("sending pending message")
 			content := []claude.ContentBlock{{Type: claude.ContentTypeText, Text: pendingMsg}}
@@ -756,7 +756,6 @@ func (w *SessionWorker) notifySupervisor(supervisorID string, testsPassed bool) 
 	}
 
 	// Queue the message for the supervisor
-	state := w.host.SessionManager().StateManager().GetOrCreate(supervisorID)
-	state.SetPendingMsg(prompt)
+	w.host.SetPendingMessage(supervisorID, prompt)
 }
 


### PR DESCRIPTION
## Summary
Removes the direct dependency from `worker` package on `manager` package by replacing the `SessionManager()` method on the `Host` interface with two focused methods: `GetPendingMessage()` and `SetPendingMessage()`.

## Changes
- Replace `Host.SessionManager()` with `GetPendingMessage(sessionID)` and `SetPendingMessage(sessionID, msg)` on the `Host` interface
- Update `Daemon` host implementation to delegate pending message operations through `sessionMgr` internally
- Update `SessionWorker` to use the new narrow interface methods instead of reaching through the session manager
- Update `mockHost` in tests to use a simple map-based implementation, removing the `manager` dependency from test setup
- Remove `manager` import from both `worker` and `daemon/host.go` packages

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all tests pass
- Verify the `worker` package no longer imports `manager`
- Confirm the compile-time interface assertion (`var _ Host = (*mockHost)(nil)`) still passes

Fixes #200