### PR TITLE
refactor: add testutil package to deduplicate test helpers

### DIFF
--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -13,12 +12,11 @@ import (
 	"time"
 
 	"github.com/zhubert/erg/internal/mcp"
+	"github.com/zhubert/erg/internal/testutil"
 )
 
 // testLogger creates a discard logger for tests
-func testLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
-}
+func testLogger() *slog.Logger { return testutil.DiscardLogger() }
 
 func TestNew(t *testing.T) {
 	tests := []struct {

--- a/internal/claude/mcp_config_test.go
+++ b/internal/claude/mcp_config_test.go
@@ -9,7 +9,7 @@ import (
 func TestCreateContainerMCPConfigLocked(t *testing.T) {
 	r := &Runner{
 		sessionID: "test-container-mcp",
-		log:       pmTestLogger(),
+		log:       testLogger(),
 	}
 
 	// Use a container port (what ensureServerRunning passes for container sessions)
@@ -91,7 +91,7 @@ func TestCreateContainerMCPConfigLocked(t *testing.T) {
 func TestCreateMCPConfigLocked_HostSession(t *testing.T) {
 	r := &Runner{
 		sessionID: "test-host-mcp",
-		log:       pmTestLogger(),
+		log:       testLogger(),
 	}
 
 	socketPath := "/tmp/pl-test-host-mcp.sock"
@@ -150,7 +150,7 @@ func TestCreateContainerMCPConfig_NoExternalServers(t *testing.T) {
 	// (not supported in container mode)
 	r := &Runner{
 		sessionID: "test-no-external",
-		log:       pmTestLogger(),
+		log:       testLogger(),
 		mcpServers: []MCPServer{
 			{Name: "external", Command: "/usr/local/bin/external", Args: []string{"serve"}},
 		},

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,39 +5,28 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/zhubert/erg/internal/daemonstate"
-	"github.com/zhubert/erg/internal/worker"
-	"github.com/zhubert/erg/internal/workflow"
 	"github.com/zhubert/erg/internal/config"
+	"github.com/zhubert/erg/internal/daemonstate"
 	"github.com/zhubert/erg/internal/exec"
 	"github.com/zhubert/erg/internal/git"
 	"github.com/zhubert/erg/internal/issues"
 	"github.com/zhubert/erg/internal/session"
+	"github.com/zhubert/erg/internal/testutil"
+	"github.com/zhubert/erg/internal/worker"
+	"github.com/zhubert/erg/internal/workflow"
 )
 
 // discardLogger returns a slog.Logger that discards all output. Useful in tests.
-func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
-}
+func discardLogger() *slog.Logger { return testutil.DiscardLogger() }
 
 // testConfig creates a minimal config for testing.
-func testConfig() *config.Config {
-	return &config.Config{
-		Repos:              []string{},
-		Sessions:           []config.Session{},
-		AllowedTools:       []string{},
-		RepoAllowedTools:   make(map[string][]string),
-		AutoMaxTurns:       50,
-		AutoMaxDurationMin: 30,
-	}
-}
+func testConfig() *config.Config { return testutil.TestConfig() }
 
 // testSession creates a minimal session for testing.
 func testSession(id string) *config.Session {
@@ -59,7 +48,7 @@ func testDaemon(cfg *config.Config) *Daemon {
 	mockExec := exec.NewMockExecutor(nil)
 	gitSvc := git.NewGitServiceWithExecutor(mockExec)
 	sessSvc := session.NewSessionServiceWithExecutor(mockExec)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	registry := issues.NewProviderRegistry()
 
 	d := New(cfg, gitSvc, sessSvc, registry, logger)
@@ -73,7 +62,7 @@ func testDaemon(cfg *config.Config) *Daemon {
 func testDaemonWithExec(cfg *config.Config, mockExec *exec.MockExecutor) *Daemon {
 	gitSvc := git.NewGitServiceWithExecutor(mockExec)
 	sessSvc := session.NewSessionServiceWithExecutor(mockExec)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	registry := issues.NewProviderRegistry()
 
 	d := New(cfg, gitSvc, sessSvc, registry, logger)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,26 @@
+// Package testutil provides shared test helpers used across packages.
+package testutil
+
+import (
+	"io"
+	"log/slog"
+
+	"github.com/zhubert/erg/internal/config"
+)
+
+// DiscardLogger returns a slog.Logger that discards all output.
+func DiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestConfig returns a minimal config suitable for unit tests.
+func TestConfig() *config.Config {
+	return &config.Config{
+		Repos:              []string{},
+		Sessions:           []config.Session{},
+		AllowedTools:       []string{},
+		RepoAllowedTools:   make(map[string][]string),
+		AutoMaxTurns:       50,
+		AutoMaxDurationMin: 30,
+	}
+}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"sync"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/zhubert/erg/internal/exec"
 	"github.com/zhubert/erg/internal/git"
 	"github.com/zhubert/erg/internal/mcp"
+	"github.com/zhubert/erg/internal/testutil"
 )
 
 // mockHost implements worker.Host for unit testing.
@@ -48,7 +48,7 @@ func newMockHost(mockExec *exec.MockExecutor) *mockHost {
 	return &mockHost{
 		cfg:             cfg,
 		gitService:      gitSvc,
-		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		logger:          testutil.DiscardLogger(),
 		maxTurns:        50,
 		maxDuration:     30,
 		autoMerge:       true,


### PR DESCRIPTION
## Summary
Extracts duplicated test helper functions (`DiscardLogger`, `TestConfig`) into a shared `internal/testutil` package, reducing copy-paste across test files.

## Changes
- Add `internal/testutil/testutil.go` with `DiscardLogger()` and `TestConfig()` shared helpers
- Replace duplicate `testLogger()` / `pmTestLogger()` / `discardLogger()` definitions in `claude`, `daemon`, `worker`, and `workflow` test files with calls to `testutil.DiscardLogger()`
- Replace duplicate `testConfig()` in `daemon` tests with `testutil.TestConfig()`
- Remove now-unused `io` imports from test files

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all tests pass with the shared helpers
- Confirm no import cycles introduced by the new `testutil` package

Fixes #201