### PR TITLE
fix: use %w instead of %v in fmt.Errorf to preserve error chains

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -58,7 +58,7 @@ func daemonize(cmd *cobra.Command, args []string) error {
 	// Validate prerequisites
 	prereqs := cli.DefaultPrerequisites()
 	if err := cli.ValidateRequired(prereqs); err != nil {
-		return fmt.Errorf("%v\n\nInstall required tools and try again", err)
+		return fmt.Errorf("%w\n\nInstall required tools and try again", err)
 	}
 
 	if !hasContainerRuntime() {
@@ -239,7 +239,7 @@ func runForeground(_ *cobra.Command, _ []string) error {
 	// Validate prerequisites
 	prereqs := cli.DefaultPrerequisites()
 	if err := cli.ValidateRequired(prereqs); err != nil {
-		return fmt.Errorf("%v\n\nInstall required tools and try again", err)
+		return fmt.Errorf("%w\n\nInstall required tools and try again", err)
 	}
 
 	if !hasContainerRuntime() {

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -598,7 +598,7 @@ func (r *Runner) SendContent(cmdCtx context.Context, content []ContentBlock) <-c
 		msgJSON, err := json.Marshal(inputMsg)
 		if err != nil {
 			r.log.Error("failed to serialize message", "error", err)
-			ch <- ResponseChunk{Error: fmt.Errorf("failed to serialize message: %v", err), Done: true}
+			ch <- ResponseChunk{Error: fmt.Errorf("failed to serialize message: %w", err), Done: true}
 			close(ch)
 			return
 		}

--- a/internal/claude/mcp_config.go
+++ b/internal/claude/mcp_config.go
@@ -73,7 +73,7 @@ func (r *Runner) ensureServerRunning() error {
 	}
 	if err != nil {
 		r.log.Error("failed to create socket server", "error", err)
-		return fmt.Errorf("failed to start permission server: %v", err)
+		return fmt.Errorf("failed to start permission server: %w", err)
 	}
 	r.socketServer = socketServer
 	r.log.Debug("socket server created", "elapsed", time.Since(startTime))
@@ -97,7 +97,7 @@ func (r *Runner) ensureServerRunning() error {
 		r.socketServer.Close()
 		r.socketServer = nil
 		r.log.Error("failed to create MCP config", "error", err)
-		return fmt.Errorf("failed to create MCP config: %v", err)
+		return fmt.Errorf("failed to create MCP config: %w", err)
 	}
 	r.mcpConfigPath = mcpConfigPath
 

--- a/internal/claude/process_manager.go
+++ b/internal/claude/process_manager.go
@@ -363,7 +363,7 @@ func (pm *ProcessManager) Start() error {
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		pm.log.Error("failed to get stdin pipe", "error", err)
-		return fmt.Errorf("failed to get stdin pipe: %v", err)
+		return fmt.Errorf("failed to get stdin pipe: %w", err)
 	}
 
 	// Get stdout pipe for reading responses
@@ -371,7 +371,7 @@ func (pm *ProcessManager) Start() error {
 	if err != nil {
 		stdin.Close()
 		pm.log.Error("failed to get stdout pipe", "error", err)
-		return fmt.Errorf("failed to get stdout pipe: %v", err)
+		return fmt.Errorf("failed to get stdout pipe: %w", err)
 	}
 
 	// Get stderr pipe for error messages
@@ -380,7 +380,7 @@ func (pm *ProcessManager) Start() error {
 		stdin.Close()
 		stdout.Close()
 		pm.log.Error("failed to get stderr pipe", "error", err)
-		return fmt.Errorf("failed to get stderr pipe: %v", err)
+		return fmt.Errorf("failed to get stderr pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -389,9 +389,9 @@ func (pm *ProcessManager) Start() error {
 		stderr.Close()
 		pm.log.Error("failed to start process", "error", err)
 		if pm.config.Containerized {
-			return fmt.Errorf("failed to start container: %v (is Docker running?)", err)
+			return fmt.Errorf("failed to start container: %w (is Docker running?)", err)
 		}
-		return fmt.Errorf("failed to start process: %v", err)
+		return fmt.Errorf("failed to start process: %w", err)
 	}
 
 	pm.cmd = cmd
@@ -564,7 +564,7 @@ func (pm *ProcessManager) WriteMessage(data []byte) error {
 	}
 
 	if _, err := stdin.Write(data); err != nil {
-		return fmt.Errorf("failed to write to process: %v", err)
+		return fmt.Errorf("failed to write to process: %w", err)
 	}
 
 	return nil
@@ -948,7 +948,7 @@ func (pm *ProcessManager) handleExit(err error) {
 				}
 			}
 			// Report fatal error
-			exitErr := fmt.Errorf("process crashed and restart failed: %v", err)
+			exitErr := fmt.Errorf("process crashed and restart failed: %w", err)
 			if pm.callbacks.OnFatalError != nil {
 				pm.callbacks.OnFatalError(exitErr)
 			}
@@ -975,7 +975,7 @@ func (pm *ProcessManager) handleExit(err error) {
 		friendly := friendlyContainerError(stderrContent, pm.config.Containerized)
 		exitErr = fmt.Errorf("process crashed repeatedly (max %d restarts): %s", MaxProcessRestartAttempts, friendly)
 	} else if err != nil {
-		exitErr = fmt.Errorf("process crashed repeatedly (max %d restarts): %v", MaxProcessRestartAttempts, err)
+		exitErr = fmt.Errorf("process crashed repeatedly (max %d restarts): %w", MaxProcessRestartAttempts, err)
 	} else {
 		exitErr = fmt.Errorf("process crashed repeatedly (max %d restarts exceeded)", MaxProcessRestartAttempts)
 	}

--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -110,7 +110,7 @@ func (a *createPRAction) Execute(ctx context.Context, ac *workflow.ActionContext
 			d.unqueueIssue(ctx, item, fmt.Sprintf("The coding session made no changes. Removing from the queue — re-add the '%s' label if this still needs work.", label))
 			return workflow.ActionResult{Success: true, OverrideNext: "done"}
 		}
-		return workflow.ActionResult{Error: fmt.Errorf("PR creation failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("PR creation failed: %w", err)}
 	}
 
 	return workflow.ActionResult{
@@ -133,7 +133,7 @@ func (a *pushAction) Execute(ctx context.Context, ac *workflow.ActionContext) wo
 	}
 
 	if err := d.pushChanges(ctx, item); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("push failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("push failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -153,7 +153,7 @@ func (a *mergeAction) Execute(ctx context.Context, ac *workflow.ActionContext) w
 	}
 
 	if err := d.mergePR(ctx, item); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("merge failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("merge failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -173,7 +173,7 @@ func (a *commentIssueAction) Execute(ctx context.Context, ac *workflow.ActionCon
 	}
 
 	if err := d.commentOnIssue(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("issue comment failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("issue comment failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -193,7 +193,7 @@ func (a *commentPRAction) Execute(ctx context.Context, ac *workflow.ActionContex
 	}
 
 	if err := d.commentOnPR(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("PR comment failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("PR comment failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -213,7 +213,7 @@ func (a *asanaCommentAction) Execute(ctx context.Context, ac *workflow.ActionCon
 	}
 
 	if err := d.commentViaProvider(ctx, item, ac.Params, issues.SourceAsana); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("asana comment failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("asana comment failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -233,7 +233,7 @@ func (a *linearCommentAction) Execute(ctx context.Context, ac *workflow.ActionCo
 	}
 
 	if err := d.commentViaProvider(ctx, item, ac.Params, issues.SourceLinear); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("linear comment failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("linear comment failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -253,7 +253,7 @@ func (a *addLabelAction) Execute(ctx context.Context, ac *workflow.ActionContext
 	}
 
 	if err := d.addLabel(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("add label failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("add label failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -273,7 +273,7 @@ func (a *removeLabelAction) Execute(ctx context.Context, ac *workflow.ActionCont
 	}
 
 	if err := d.removeLabel(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("remove label failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("remove label failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -293,7 +293,7 @@ func (a *closeIssueAction) Execute(ctx context.Context, ac *workflow.ActionConte
 	}
 
 	if err := d.closeIssue(ctx, item); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("close issue failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("close issue failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -313,7 +313,7 @@ func (a *requestReviewAction) Execute(ctx context.Context, ac *workflow.ActionCo
 	}
 
 	if err := d.requestReview(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("request review failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("request review failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -512,7 +512,7 @@ func (a *formatAction) Execute(ctx context.Context, ac *workflow.ActionContext) 
 	}
 
 	if err := d.runFormatter(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("format failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("format failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -583,7 +583,7 @@ func (a *slackNotifyAction) Execute(ctx context.Context, ac *workflow.ActionCont
 	}
 
 	if err := d.sendSlackNotification(ctx, item, ac.Params); err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("slack.notify failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("slack.notify failed: %w", err)}
 	}
 
 	return workflow.ActionResult{Success: true}
@@ -717,7 +717,7 @@ func (a *webhookPostAction) Execute(ctx context.Context, ac *workflow.ActionCont
 
 	statusCode, err := d.postWebhook(ctx, item, ac.Params)
 	if err != nil {
-		return workflow.ActionResult{Error: fmt.Errorf("webhook.post failed: %v", err)}
+		return workflow.ActionResult{Error: fmt.Errorf("webhook.post failed: %w", err)}
 	}
 
 	return workflow.ActionResult{

--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -5162,3 +5162,78 @@ func TestWebhookPostAction_Execute_CustomTimeout(t *testing.T) {
 		t.Errorf("expected success with custom timeout, got error: %v", result.Error)
 	}
 }
+
+// TestActionErrorWrapping verifies that action Execute methods use %w so that
+// errors.Is can traverse the chain from the outer ActionResult.Error back to
+// the original sentinel / leaf error returned by the underlying operation.
+func TestActionErrorWrapping(t *testing.T) {
+	// sentinelErr is the leaf error injected via the mock executor.
+	sentinelErr := errors.New("sentinel gh failure")
+
+	setup := func(t *testing.T, prefixArgs []string) (*Daemon, *config.Config, *exec.MockExecutor) {
+		t.Helper()
+		cfg := testConfig()
+		mockExec := exec.NewMockExecutor(nil)
+		mockExec.AddPrefixMatch("gh", prefixArgs, exec.MockResponse{Err: sentinelErr})
+		gitSvc := git.NewGitServiceWithExecutor(mockExec)
+		d := testDaemonWithExec(cfg, mockExec)
+		d.gitService = gitSvc
+		d.repoFilter = "/test/repo"
+		sess := testSession("sess-1")
+		cfg.AddSession(*sess)
+		d.state.AddWorkItem(&daemonstate.WorkItem{
+			ID:        "item-1",
+			IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+			SessionID: "sess-1",
+		})
+		return d, cfg, mockExec
+	}
+
+	t.Run("commentIssueAction wraps error", func(t *testing.T) {
+		d, _, _ := setup(t, []string{"issue", "comment"})
+		action := &commentIssueAction{daemon: d}
+		ac := &workflow.ActionContext{
+			WorkItemID: "item-1",
+			Params:     workflow.NewParamHelper(map[string]any{"body": "hello"}),
+		}
+		result := action.Execute(context.Background(), ac)
+		if result.Success {
+			t.Fatal("expected failure")
+		}
+		if !errors.Is(result.Error, sentinelErr) {
+			t.Errorf("errors.Is did not find sentinel in chain: %v", result.Error)
+		}
+	})
+
+	t.Run("addLabelAction wraps error", func(t *testing.T) {
+		d, _, _ := setup(t, []string{"issue", "edit"})
+		action := &addLabelAction{daemon: d}
+		ac := &workflow.ActionContext{
+			WorkItemID: "item-1",
+			Params:     workflow.NewParamHelper(map[string]any{"label": "bug"}),
+		}
+		result := action.Execute(context.Background(), ac)
+		if result.Success {
+			t.Fatal("expected failure")
+		}
+		if !errors.Is(result.Error, sentinelErr) {
+			t.Errorf("errors.Is did not find sentinel in chain: %v", result.Error)
+		}
+	})
+
+	t.Run("removeLabelAction wraps error", func(t *testing.T) {
+		d, _, _ := setup(t, []string{"issue", "edit"})
+		action := &removeLabelAction{daemon: d}
+		ac := &workflow.ActionContext{
+			WorkItemID: "item-1",
+			Params:     workflow.NewParamHelper(map[string]any{"label": "bug"}),
+		}
+		result := action.Execute(context.Background(), ac)
+		if result.Success {
+			t.Fatal("expected failure")
+		}
+		if !errors.Is(result.Error, sentinelErr) {
+			t.Errorf("errors.Is did not find sentinel in chain: %v", result.Error)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Replace `%v` with `%w` in `fmt.Errorf` calls across the codebase so that wrapped errors remain unwrappable via `errors.Is` and `errors.As`.

## Changes
- Update all `fmt.Errorf` calls that wrap an existing `err` to use the `%w` verb instead of `%v` in `cmd/agent.go`, `internal/claude/`, and `internal/daemon/actions.go`
- Add `TestActionErrorWrapping` to verify that action errors properly chain back to the original sentinel error using `errors.Is`

## Test plan
- Run `go test -p=1 -count=1 ./...` and confirm all tests pass
- New `TestActionErrorWrapping` covers `commentIssueAction`, `addLabelAction`, and `removeLabelAction` to assert `errors.Is` traverses the wrapped chain

Fixes #199