### PR TITLE
feat(daemon): add ci.wait_for_checks event for explicit CI polling

### DIFF
--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -187,10 +187,11 @@ func DefaultRetryForAction(action string) []RetryConfig {
 
 // ValidEvents is the set of recognized event names for wait states.
 var ValidEvents = map[string]bool{
-	"pr.reviewed":   true,
-	"ci.complete":   true,
-	"pr.mergeable":  true,
-	"gate.approved": true,
+	"pr.reviewed":       true,
+	"ci.complete":       true,
+	"ci.wait_for_checks": true,
+	"pr.mergeable":      true,
+	"gate.approved":     true,
 }
 
 // ValidStateTypes is the set of recognized state types.


### PR DESCRIPTION
## Summary
Adds a new `ci.wait_for_checks` workflow event that waits for all GitHub CI checks to reach a terminal state, regardless of pass/fail outcome. Unlike `ci.complete` (which only fires on success), this event fires once all checks finish and exposes individual check results for downstream routing in choice states.

## Changes
- Add `GetPRCheckDetails` method to `GitService` that fetches individual check run results (name, state, link) via `gh pr checks --json`
- Add `CheckRun` struct in `internal/git/github.go` to represent individual check results
- Implement `checkCIWaitForChecks` event handler in `internal/daemon/events.go` that:
  - Polls for check completion (all checks in terminal state)
  - Returns `ci_status` ("passing", "failing", or "none") along with `passed_checks` and `failed_checks` lists
  - Handles edge cases: no session, API errors, no checks configured, pending checks
- Register `ci.wait_for_checks` in `ValidEvents` and the `CheckEvent` dispatcher
- Add comprehensive tests for both the git service method and the daemon event handler

## Test plan
- Run `go test -p=1 -count=1 ./internal/git/...` to verify `GetPRCheckDetails` tests
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify event handler tests
- Run `go test -p=1 -count=1 ./...` to verify no regressions
- Tests cover: all passing, some failing, pending checks, no checks, API errors, missing session, and event dispatch routing

Fixes #191