### PR TITLE
feat(workflow): add workflow.wait action for configurable pauses

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -314,6 +314,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("linear.comment", &linearCommentAction{daemon: d})
 	registry.Register("slack.notify", &slackNotifyAction{daemon: d})
 	registry.Register("webhook.post", &webhookPostAction{daemon: d})
+	registry.Register("workflow.wait", &waitAction{daemon: d})
 	return registry
 }
 

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -145,6 +145,7 @@ var ValidActions = map[string]bool{
 	"git.rebase":            true,
 	"asana.comment":         true,
 	"linear.comment":        true,
+	"workflow.wait":         true,
 }
 
 // RetryableActions is the set of network-bound actions that should be retried


### PR DESCRIPTION
## Summary
Adds a new `workflow.wait` action that allows configurable pauses between workflow steps, enabling users to introduce deliberate delays in their workflow configurations.

## Changes
- Add `waitAction` struct and `Execute` method in `internal/daemon/actions.go` that pauses for a configurable duration with clean context cancellation support
- Register `workflow.wait` in the daemon's action registry
- Add `workflow.wait` to the `ValidActions` map in workflow config
- Add comprehensive tests covering: successful wait completion, zero/missing duration (immediate return), context cancellation, and registry registration

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify the new action tests pass
- Run `go test -p=1 -count=1 ./internal/workflow/...` to verify config validation accepts the new action
- Run `go test -p=1 -count=1 ./...` for full suite

Fixes #188