### PR TITLE
feat(daemon): add ai.write_pr_description action for rich PR bodies

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -5458,3 +5458,184 @@ func TestWaitAction_Execute(t *testing.T) {
 		}
 	})
 }
+
+func TestWritePRDescriptionAction_WorkItemNotFound(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	action := &writePRDescriptionAction{daemon: d}
+	ac := &workflow.ActionContext{
+		WorkItemID: "nonexistent",
+		Params:     workflow.NewParamHelper(nil),
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure for missing work item")
+	}
+	if result.Error == nil {
+		t.Error("expected error for missing work item")
+	}
+}
+
+func TestWritePRDescriptionAction_SessionNotFound(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "session-does-not-exist",
+		Branch:    "feature-42",
+		StepData:  map[string]any{},
+	})
+
+	action := &writePRDescriptionAction{daemon: d}
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     workflow.NewParamHelper(nil),
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure when session not found")
+	}
+	if result.Error == nil {
+		t.Error("expected error when session not found")
+	}
+}
+
+func TestWritePRDescriptionAction_Success(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// git fetch origin
+	mockExec.AddPrefixMatch("git", []string{"fetch", "origin"}, exec.MockResponse{})
+	// git rev-parse --verify origin/main
+	mockExec.AddPrefixMatch("git", []string{"rev-parse", "--verify"}, exec.MockResponse{
+		Stdout: []byte("abc123\n"),
+	})
+	// git log
+	mockExec.AddPrefixMatch("git", []string{"log"}, exec.MockResponse{
+		Stdout: []byte("abc123 feat: add feature\n"),
+	})
+	// git diff
+	mockExec.AddPrefixMatch("git", []string{"diff"}, exec.MockResponse{
+		Stdout: []byte("diff --git a/foo.go b/foo.go\n+new line\n"),
+	})
+	// claude --print -p ...
+	mockExec.AddPrefixMatch("claude", []string{"--print", "-p"}, exec.MockResponse{
+		Stdout: []byte("## Summary\nThis PR adds a feature.\n\n## Changes\n- Added foo.go\n\n## Test plan\n- Run tests\n\n## Breaking changes\nNone"),
+	})
+	// gh pr edit --body ...
+	mockExec.AddPrefixMatch("gh", []string{"pr", "edit"}, exec.MockResponse{})
+	// git symbolic-ref (for GetDefaultBranch)
+	mockExec.AddPrefixMatch("git", []string{"symbolic-ref"}, exec.MockResponse{
+		Stdout: []byte("refs/remotes/origin/main\n"),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+
+	sess := testSession("sess-1")
+	sess.BaseBranch = "main"
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+		Branch:    "feature-sess-1",
+		StepData:  map[string]any{},
+	})
+
+	action := &writePRDescriptionAction{daemon: d}
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     workflow.NewParamHelper(nil),
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if !result.Success {
+		t.Errorf("expected success, got error: %v", result.Error)
+	}
+
+	// Verify gh pr edit was called
+	calls := mockExec.GetCalls()
+	found := false
+	for _, c := range calls {
+		if c.Name == "gh" && len(c.Args) >= 3 && c.Args[0] == "pr" && c.Args[1] == "edit" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected gh pr edit to be called to update PR body")
+	}
+}
+
+func TestWritePRDescriptionAction_ClaudeFailure(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	mockExec.AddPrefixMatch("git", []string{"fetch", "origin"}, exec.MockResponse{})
+	mockExec.AddPrefixMatch("git", []string{"rev-parse", "--verify"}, exec.MockResponse{
+		Stdout: []byte("abc123\n"),
+	})
+	mockExec.AddPrefixMatch("git", []string{"log"}, exec.MockResponse{
+		Stdout: []byte("abc123 feat: something\n"),
+	})
+	mockExec.AddPrefixMatch("git", []string{"diff"}, exec.MockResponse{
+		Stdout: []byte("diff output\n"),
+	})
+	mockExec.AddPrefixMatch("claude", []string{"--print", "-p"}, exec.MockResponse{
+		Err: fmt.Errorf("claude: not found"),
+	})
+	mockExec.AddPrefixMatch("git", []string{"symbolic-ref"}, exec.MockResponse{
+		Stdout: []byte("refs/remotes/origin/main\n"),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+
+	sess := testSession("sess-2")
+	sess.BaseBranch = "main"
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:        "item-2",
+		IssueRef:  config.IssueRef{Source: "github", ID: "43"},
+		SessionID: "sess-2",
+		Branch:    "feature-sess-2",
+		StepData:  map[string]any{},
+	})
+
+	action := &writePRDescriptionAction{daemon: d}
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-2",
+		Params:     workflow.NewParamHelper(nil),
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure when Claude fails")
+	}
+	if result.Error == nil {
+		t.Error("expected non-nil error when Claude fails")
+	}
+}
+
+func TestWritePRDescriptionAction_RegisteredInRegistry(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	registry := d.buildActionRegistry()
+	if registry.Get("ai.write_pr_description") == nil {
+		t.Error("ai.write_pr_description not registered in action registry")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -307,6 +307,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("github.request_review", &requestReviewAction{daemon: d})
 	registry.Register("ai.fix_ci", &fixCIAction{daemon: d})
 	registry.Register("ai.address_review", &addressReviewAction{daemon: d})
+	registry.Register("ai.write_pr_description", &writePRDescriptionAction{daemon: d})
 	registry.Register("git.format", &formatAction{daemon: d})
 	registry.Register("git.rebase", &rebaseAction{daemon: d})
 	registry.Register("git.squash", &squashAction{daemon: d})

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -1006,6 +1006,109 @@ Diff:
 	return title, body, nil
 }
 
+// UpdatePRBody updates the body of an existing pull request using the gh CLI.
+func (s *GitService) UpdatePRBody(ctx context.Context, repoPath, branch, body string) error {
+	_, _, err := s.executor.Run(ctx, repoPath, "gh", "pr", "edit", branch, "--body", body)
+	if err != nil {
+		return fmt.Errorf("gh pr edit --body failed: %w", err)
+	}
+	return nil
+}
+
+// GenerateRichPRDescription uses Claude to generate a rich PR description from the diff and
+// commit messages. The description includes a summary, test plan, and breaking change notes.
+// Unlike GeneratePRTitleAndBodyWithIssueRef, this focuses on description quality rather than
+// also generating a title, and uses a tailored prompt for richer output.
+//
+// baseBranch is the branch this PR will be compared against (typically the session's BaseBranch or main).
+func (s *GitService) GenerateRichPRDescription(ctx context.Context, repoPath, branch, baseBranch string, issueRef *config.IssueRef) (string, error) {
+	log := logger.WithComponent("git")
+	log.Info("generating rich PR description with Claude", "branch", branch, "baseBranch", baseBranch)
+
+	if baseBranch == "" {
+		baseBranch = s.GetDefaultBranch(ctx, repoPath)
+	}
+
+	// Use origin/<baseBranch> for git comparisons.
+	comparisonRef := baseBranch
+	_, fetchErr := s.executor.CombinedOutput(ctx, repoPath, "git", "fetch", "origin", baseBranch)
+	if fetchErr == nil {
+		candidateRef := fmt.Sprintf("origin/%s", baseBranch)
+		_, _, verifyErr := s.executor.Run(ctx, repoPath, "git", "rev-parse", "--verify", candidateRef)
+		if verifyErr == nil {
+			comparisonRef = candidateRef
+		}
+	}
+
+	// Get the commit log for this branch.
+	commitLog, err := s.executor.Output(ctx, repoPath, "git", "log",
+		fmt.Sprintf("%s..%s", comparisonRef, branch), "--oneline")
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit log: %w", err)
+	}
+
+	// Get the diff from base branch.
+	diffOutput, err := s.executor.Output(ctx, repoPath, "git", "diff", "--no-ext-diff",
+		fmt.Sprintf("%s...%s", comparisonRef, branch))
+	if err != nil {
+		return "", fmt.Errorf("failed to get diff: %w", err)
+	}
+
+	fullDiff := string(diffOutput)
+	if len(fullDiff) > MaxDiffSize {
+		fullDiff = fullDiff[:MaxDiffSize] + "\n... (diff truncated)"
+	}
+
+	// Build a description-focused prompt that produces richer output than the PR-creation prompt.
+	issueContext := ""
+	if issueRef != nil && issueRef.Title != "" {
+		issueContext = fmt.Sprintf("\nIssue being addressed: %s", issueRef.Title)
+	}
+
+	prompt := fmt.Sprintf(`You are writing a GitHub pull request description. Analyze the diff and commit messages below and produce a rich, informative PR body.%s
+
+Output ONLY the PR body markdown — no preamble, no meta-commentary. Use this exact structure:
+
+## Summary
+1-3 sentences explaining what this PR does and why.
+
+## Changes
+Bullet points of the key changes made (be specific, reference files/functions where helpful).
+
+## Test plan
+- Concrete steps a reviewer can follow to verify the changes work correctly.
+
+## Breaking changes
+List any breaking changes (API changes, removed flags, changed defaults). Write "None" if there are none.
+
+Commits in this branch:
+%s
+
+Diff:
+%s`, issueContext, strings.TrimSpace(string(commitLog)), fullDiff)
+
+	output, err := s.executor.Output(ctx, repoPath, "claude", "--print", "-p", prompt)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate PR description with Claude: %w", err)
+	}
+
+	body := strings.TrimSpace(string(output))
+	if body == "" {
+		return "", fmt.Errorf("Claude returned empty PR description")
+	}
+
+	// Append issue link if applicable.
+	if issueRef != nil {
+		linkText := GetPRLinkText(issueRef)
+		if linkText != "" {
+			body = body + linkText
+		}
+	}
+
+	log.Info("generated rich PR description", "branch", branch, "bodyLen", len(body))
+	return body, nil
+}
+
 // GetPRLinkText returns the appropriate text to add to a PR body based on the issue source.
 // For GitHub issues: returns "\n\nFixes #123"
 // For Asana tasks: returns "" (no auto-close support)


### PR DESCRIPTION
## Summary
Adds a new `ai.write_pr_description` workflow action that uses Claude to generate rich, structured PR descriptions from branch diffs and commit messages, then updates the open PR body via `gh pr edit`.

## Changes
- Add `writePRDescriptionAction` struct and `Execute` method in `internal/daemon/actions.go`
- Add `writePRDescription` orchestration method in `internal/daemon/coding.go` that refreshes the session, resolves the base branch, and coordinates description generation with PR update
- Register `ai.write_pr_description` in the daemon's action registry (`internal/daemon/daemon.go`)
- Add `GenerateRichPRDescription` to `GitService` (`internal/git/github.go`) — fetches commit log and diff against the base branch, sends a tailored prompt to Claude, and returns structured markdown with Summary, Changes, Test plan, and Breaking changes sections
- Add `UpdatePRBody` to `GitService` for updating an existing PR's body via `gh pr edit`
- Comprehensive tests for the action (work item not found, session not found, success, Claude failure, registry registration) and git service methods (success, CLI error, Claude error, empty output, git log error)

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify action tests pass
- Run `go test -p=1 -count=1 ./internal/git/...` to verify git service tests pass
- Run `go test -p=1 -count=1 ./...` for full suite
- Verify the action can be used in a workflow config by referencing `ai.write_pr_description` as a step action

Fixes #179