### PR TITLE
feat(daemon): add github.create_draft_pr action and draft param to create_pr

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -297,6 +297,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry := workflow.NewActionRegistry()
 	registry.Register("ai.code", &codingAction{daemon: d})
 	registry.Register("github.create_pr", &createPRAction{daemon: d})
+	registry.Register("github.create_draft_pr", &createDraftPRAction{daemon: d})
 	registry.Register("github.push", &pushAction{daemon: d})
 	registry.Register("github.merge", &mergeAction{daemon: d})
 	registry.Register("github.comment_issue", &commentIssueAction{daemon: d})

--- a/internal/daemon/github_ops.go
+++ b/internal/daemon/github_ops.go
@@ -18,7 +18,8 @@ import (
 )
 
 // createPR creates a pull request for a work item's session.
-func (d *Daemon) createPR(ctx context.Context, item daemonstate.WorkItem) (string, error) {
+// When draft is true the PR is created in draft state.
+func (d *Daemon) createPR(ctx context.Context, item daemonstate.WorkItem, draft bool) (string, error) {
 	sess := d.config.GetSession(item.SessionID)
 	if sess == nil {
 		return "", fmt.Errorf("session not found")
@@ -59,7 +60,7 @@ func (d *Daemon) createPR(ctx context.Context, item daemonstate.WorkItem) (strin
 	prCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	resultCh := d.gitService.CreatePR(prCtx, sess.RepoPath, sess.WorkTree, sess.Branch, sess.BaseBranch, "", sess.GetIssueRef(), item.SessionID)
+	resultCh := d.gitService.CreatePR(prCtx, sess.RepoPath, sess.WorkTree, sess.Branch, sess.BaseBranch, "", sess.GetIssueRef(), item.SessionID, draft)
 
 	var lastErr error
 	var prURL string

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -247,7 +247,8 @@ func (s *GitService) AbortMerge(ctx context.Context, repoPath string) error {
 // If issueRef is provided, appropriate link text will be added to the PR body based on the source.
 // baseBranch is the branch this PR should be compared against (typically the session's BaseBranch).
 // sessionID is used to load and upload the session transcript as a PR comment; pass "" to skip.
-func (s *GitService) CreatePR(ctx context.Context, repoPath, worktreePath, branch, baseBranch, commitMsg string, issueRef *config.IssueRef, sessionID string) <-chan Result {
+// draft controls whether the PR is created as a draft PR.
+func (s *GitService) CreatePR(ctx context.Context, repoPath, worktreePath, branch, baseBranch, commitMsg string, issueRef *config.IssueRef, sessionID string, draft bool) <-chan Result {
 	ch := make(chan Result)
 
 	go func() {
@@ -290,6 +291,9 @@ func (s *GitService) CreatePR(ctx context.Context, repoPath, worktreePath, branc
 			ch <- Result{Output: fmt.Sprintf("PR title: %s\n", prTitle)}
 			// Create PR with Claude-generated title and body
 			ghArgs = []string{"pr", "create", "--base", baseBranch, "--head", branch, "--title", prTitle, "--body", prBody}
+		}
+		if draft {
+			ghArgs = append(ghArgs, "--draft")
 		}
 
 		// Run gh pr create using the executor


### PR DESCRIPTION
## Summary
Adds a new `github.create_draft_pr` workflow action and extends `github.create_pr` with an optional `draft` parameter, allowing workflows to create draft pull requests.

## Changes
- Add `draft` boolean parameter to `Daemon.createPR()` and `GitService.CreatePR()`, appending `--draft` to `gh pr create` when true
- Add new `createDraftPRAction` struct implementing `github.create_draft_pr` as a convenience action (equivalent to `github.create_pr` with `draft=true`)
- Register `github.create_draft_pr` in the daemon's action registry
- Update all existing callers of `createPR`/`CreatePR` to pass `draft=false` for backward compatibility

## Test plan
- `TestCreateDraftPRAction_WorkItemNotFound` — verifies error on missing work item
- `TestCreateDraftPRAction_NoChanges_UnqueuesIssue` — verifies no-changes path unqueues and returns `done`
- `TestCreateDraftPRAction_RegisteredInRegistry` — verifies action is wired into the registry
- `TestCreatePRAction_DraftParam_PassedThrough` — verifies `github.create_pr` reads the `draft` param
- `TestCreatePR_DraftFlag` / `TestCreatePR_NoDraftFlag` — verifies `--draft` is present/absent in the `gh` CLI call
- Run full suite: `go test -p=1 -count=1 ./...`

Fixes #182