### PR TITLE
docs: move pr.mergeable event to the PR events section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3307,77 +3307,6 @@
           </div>
         </div>
 
-        <h3 id="events-ci">CI events</h3>
-
-        <div class="action-ref">
-          <div class="action-header">
-            <span class="action-title">ci.complete</span>
-          </div>
-          <p class="action-desc">
-            Fires when all CI checks on the PR pass. Configurable behaviour
-            on CI failure lets workflows route to <code>ai.fix_ci</code> or
-            other states.
-          </p>
-          <div class="param-section">
-            <div class="param-section-title">Params</div>
-            <table class="param-table">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Type</th>
-                  <th>Default</th>
-                  <th>Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>on_failure</td>
-                  <td>string</td>
-                  <td>retry</td>
-                  <td>
-                    Action when CI fails: <code>retry</code> — keep waiting
-                    (default); <code>fix</code> — fire the event so the
-                    workflow can route to <code>ai.fix_ci</code>;
-                    <code>abandon</code> or <code>notify</code> — emit data
-                    for downstream routing without advancing.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div class="param-section">
-            <div class="param-section-title">Output data</div>
-            <table class="param-table">
-              <thead>
-                <tr>
-                  <th>Key</th>
-                  <th>Type</th>
-                  <th>Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>ci_passed</td>
-                  <td>bool</td>
-                  <td>True when all checks pass.</td>
-                </tr>
-                <tr>
-                  <td>ci_failed</td>
-                  <td>bool</td>
-                  <td>True when any check fails.</td>
-                </tr>
-                <tr>
-                  <td>ci_action</td>
-                  <td>string</td>
-                  <td>
-                    The <code>on_failure</code> strategy that was applied.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
         <div class="action-ref">
           <div class="action-header">
             <span class="action-title">pr.mergeable</span>
@@ -3445,6 +3374,77 @@
                   <td>pr_merged_externally</td>
                   <td>bool</td>
                   <td>True if the PR was merged outside the daemon.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <h3 id="events-ci">CI events</h3>
+
+        <div class="action-ref">
+          <div class="action-header">
+            <span class="action-title">ci.complete</span>
+          </div>
+          <p class="action-desc">
+            Fires when all CI checks on the PR pass. Configurable behaviour
+            on CI failure lets workflows route to <code>ai.fix_ci</code> or
+            other states.
+          </p>
+          <div class="param-section">
+            <div class="param-section-title">Params</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>on_failure</td>
+                  <td>string</td>
+                  <td>retry</td>
+                  <td>
+                    Action when CI fails: <code>retry</code> — keep waiting
+                    (default); <code>fix</code> — fire the event so the
+                    workflow can route to <code>ai.fix_ci</code>;
+                    <code>abandon</code> or <code>notify</code> — emit data
+                    for downstream routing without advancing.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="param-section">
+            <div class="param-section-title">Output data</div>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ci_passed</td>
+                  <td>bool</td>
+                  <td>True when all checks pass.</td>
+                </tr>
+                <tr>
+                  <td>ci_failed</td>
+                  <td>bool</td>
+                  <td>True when any check fails.</td>
+                </tr>
+                <tr>
+                  <td>ci_action</td>
+                  <td>string</td>
+                  <td>
+                    The <code>on_failure</code> strategy that was applied.
+                  </td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
Relocates the `pr.mergeable` event documentation from the CI events section to the PR events section, where it logically belongs.

## Changes
- Move `pr.mergeable` event block above the CI events heading so it sits with other PR events
- Move `ci.complete` event block back under the CI events heading
- No content changes — this is purely a reordering of existing documentation

## Test plan
- Open `docs/index.html` in a browser and verify `pr.mergeable` appears in the PR events section
- Verify `ci.complete` appears under the CI events heading
- Confirm all params and output tables render correctly for both events

Fixes #227