### PR TITLE
docs: add rendered message example for slack.notify

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3277,6 +3277,16 @@
       channel: "#eng-deployments"              # optional — overrides webhook default
     next: done</pre>
             </div>
+            <p style="margin: 0.6rem 0 0.25rem; font-size: 0.82rem; color: var(--text-muted);">
+              Given an issue titled <em>"Fix login redirect loop"</em> with ID <code>42</code> and a merged PR, the message posted to Slack would be:
+            </p>
+            <div class="code-block" style="margin-top: 0.25rem;">
+              <div class="code-header">
+                <span class="code-filename">Slack message (rendered)</span>
+              </div>
+              <pre>Merged: Fix login redirect loop (#42)
+https://github.com/your-org/your-repo/pull/99</pre>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Adds a concrete example showing what a rendered Slack notification looks like when the `slack.notify` action fires.

## Changes
- Added a rendered message example below the `slack.notify` configuration snippet in the docs page
- Shows how an issue title, ID, and PR link appear in the actual Slack message

## Test plan
- Open `docs/index.html` in a browser and verify the rendered Slack message example displays correctly below the `slack.notify` code block
- Confirm styling is consistent with surrounding documentation elements

Fixes #229