### PR TITLE
refactor: consolidate helpers and constants

### DIFF
--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -49,7 +49,7 @@ func (c *eventChecker) checkPRReviewed(ctx context.Context, params *workflow.Par
 		return false, nil, nil
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutQuickAPI)
 	defer cancel()
 
 	// Check if PR was closed
@@ -158,7 +158,7 @@ func (c *eventChecker) checkCIComplete(ctx context.Context, params *workflow.Par
 		return false, nil, nil
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
 	defer cancel()
 
 	// Check mergeable status first — conflicts prevent CI from running
@@ -227,7 +227,7 @@ func (c *eventChecker) checkPRMergeable(ctx context.Context, params *workflow.Pa
 		return false, nil, nil
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
 	defer cancel()
 
 	// Check PR state
@@ -305,7 +305,7 @@ func (c *eventChecker) checkCIWaitForChecks(ctx context.Context, params *workflo
 		return false, nil, nil
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
 	defer cancel()
 
 	checks, err := d.gitService.GetPRCheckDetails(pollCtx, sess.RepoPath, item.Branch)
@@ -393,7 +393,7 @@ func (c *eventChecker) checkGateApproved(ctx context.Context, params *workflow.P
 		return false, nil, nil
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutQuickAPI)
 	defer cancel()
 
 	trigger := params.String("trigger", "label_added")

--- a/internal/daemon/helpers.go
+++ b/internal/daemon/helpers.go
@@ -1,0 +1,18 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/zhubert/erg/internal/config"
+)
+
+// getSessionOrError retrieves the session for the given ID or returns a
+// descriptive error. This consolidates the repeated nil-check pattern used
+// across action and github_ops handlers that return an error on missing sessions.
+func (d *Daemon) getSessionOrError(sessionID string) (*config.Session, error) {
+	sess := d.config.GetSession(sessionID)
+	if sess == nil {
+		return nil, fmt.Errorf("session not found: %s", sessionID)
+	}
+	return sess, nil
+}

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/zhubert/erg/internal/config"
+	"github.com/zhubert/erg/internal/testutil"
+)
+
+func TestGetSessionOrError(t *testing.T) {
+	tests := []struct {
+		name      string
+		sessionID string
+		setup     func(*config.Config)
+		wantErr   bool
+	}{
+		{
+			name:      "found",
+			sessionID: "sess-1",
+			setup: func(c *config.Config) {
+				c.AddSession(config.Session{ID: "sess-1", RepoPath: "/repo"})
+			},
+			wantErr: false,
+		},
+		{
+			name:      "not found",
+			sessionID: "nonexistent",
+			setup:     func(c *config.Config) {},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testutil.TestConfig()
+			tt.setup(cfg)
+
+			d := &Daemon{config: cfg}
+			sess, err := d.getSessionOrError(tt.sessionID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if sess != nil {
+					t.Fatal("expected nil session on error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if sess == nil {
+					t.Fatal("expected non-nil session")
+				}
+				if sess.ID != tt.sessionID {
+					t.Errorf("session ID = %q, want %q", sess.ID, tt.sessionID)
+				}
+			}
+		})
+	}
+}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -46,7 +46,7 @@ func (d *Daemon) shutdown() {
 	select {
 	case <-done:
 		d.logger.Info("all workers shut down")
-	case <-time.After(30 * time.Second):
+	case <-time.After(timeoutStandardOp):
 		d.logger.Warn("shutdown timed out")
 	}
 

--- a/internal/daemon/polling.go
+++ b/internal/daemon/polling.go
@@ -54,7 +54,7 @@ func (d *Daemon) pollForNewIssues(ctx context.Context) {
 		return
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
 	defer cancel()
 
 	for _, repoPath := range pollingRepos {

--- a/internal/daemon/processing.go
+++ b/internal/daemon/processing.go
@@ -656,7 +656,7 @@ func (d *Daemon) checkDockerHealth() bool {
 
 // defaultDockerHealthCheck runs "docker version" with a 5-second timeout.
 func defaultDockerHealthCheck() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDockerHealth)
 	defer cancel()
 	return osexec.CommandContext(ctx, "docker", "version").Run()
 }

--- a/internal/daemon/recovery.go
+++ b/internal/daemon/recovery.go
@@ -125,7 +125,7 @@ func (d *Daemon) recoverWaitPhase(ctx context.Context, item *daemonstate.WorkIte
 		return
 	}
 
-	pollCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutQuickAPI)
 	defer cancel()
 
 	prState, err := d.gitService.GetPRState(pollCtx, sess.RepoPath, item.Branch)
@@ -221,7 +221,7 @@ func (d *Daemon) recoverAsyncPending(ctx context.Context, item *daemonstate.Work
 	}
 
 	// Check if PR was already created
-	pollCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	pollCtx, cancel := context.WithTimeout(ctx, timeoutQuickAPI)
 	defer cancel()
 
 	prState, err := d.gitService.GetPRState(pollCtx, sess.RepoPath, item.Branch)

--- a/internal/daemon/timeouts.go
+++ b/internal/daemon/timeouts.go
@@ -1,0 +1,35 @@
+package daemon
+
+import "time"
+
+// Timeout constants for context deadlines across daemon operations.
+// These replace magic duration literals to make timeout budgets visible
+// and easy to tune in one place. Test files intentionally use their own
+// literals so that test timeouts are self-contained and obvious.
+const (
+	// timeoutQuickAPI is for fast API calls and status checks
+	// (PR state, PR URL, branch-has-changes, gate labels, Slack notify).
+	timeoutQuickAPI = 15 * time.Second
+
+	// timeoutStandardOp is for standard-weight operations
+	// (comments, labels, polling, review fetches, worktree add, PR body update).
+	timeoutStandardOp = 30 * time.Second
+
+	// timeoutGitHubMerge is for heavier single-shot GitHub operations
+	// (merge PR, create release, fetch CI failure logs).
+	timeoutGitHubMerge = 60 * time.Second
+
+	// timeoutGitPush is for operations that push data to a remote
+	// (push updates, create PR, rebase-linearize, diff validation).
+	timeoutGitPush = 2 * time.Minute
+
+	// timeoutPRDescription is for AI-generated PR description generation.
+	timeoutPRDescription = 3 * time.Minute
+
+	// timeoutGitRewrite is for history-rewriting operations
+	// (rebase, squash, cherry-pick, format, merge-base-into-branch).
+	timeoutGitRewrite = 5 * time.Minute
+
+	// timeoutDockerHealth is for the Docker daemon health check.
+	timeoutDockerHealth = 5 * time.Second
+)

--- a/internal/issues/httpclient.go
+++ b/internal/issues/httpclient.go
@@ -1,0 +1,60 @@
+package issues
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// apiRequest performs an HTTP request with common boilerplate shared by the
+// Asana and Linear providers: build the request, set auth/content headers,
+// execute, check for 403 and unexpected status codes, and optionally JSON-
+// decode the response body.
+//
+// Parameters:
+//   - ctx: request context
+//   - client: HTTP client to use
+//   - method: HTTP method (GET, POST, etc.)
+//   - url: fully-formed request URL
+//   - body: request body (may be nil for GET requests)
+//   - authHeader: value for the Authorization header (e.g. "Bearer <token>" or raw key)
+//   - expectStatus: expected success status code (e.g. http.StatusOK, http.StatusCreated)
+//   - forbiddenMsg: if non-empty, returned as the error message on 403; if empty, 403 falls through to generic status check
+//   - providerName: name used in generic error messages (e.g. "Asana", "Linear")
+//   - result: target for JSON decoding (may be nil to skip decoding)
+func apiRequest(ctx context.Context, client *http.Client, method, url string, body io.Reader, authHeader string, expectStatus int, forbiddenMsg, providerName string, result any) error {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", authHeader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s API request failed: %w", providerName, err)
+	}
+	defer resp.Body.Close()
+
+	if forbiddenMsg != "" && resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("%s", forbiddenMsg)
+	}
+
+	if resp.StatusCode != expectStatus {
+		return fmt.Errorf("%s API returned status %d", providerName, resp.StatusCode)
+	}
+
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", providerName, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/issues/httpclient_test.go
+++ b/internal/issues/httpclient_test.go
@@ -1,0 +1,106 @@
+package issues
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAPIRequest_Success(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("auth header = %q, want %q", got, "Bearer tok")
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("accept header = %q, want %q", got, "application/json")
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(payload{Name: "hello"})
+	}))
+	defer srv.Close()
+
+	var result payload
+	err := apiRequest(context.Background(), srv.Client(), http.MethodGet, srv.URL, nil,
+		"Bearer tok", http.StatusOK, "", "Test", &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "hello" {
+		t.Errorf("result.Name = %q, want %q", result.Name, "hello")
+	}
+}
+
+func TestAPIRequest_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	err := apiRequest(context.Background(), srv.Client(), http.MethodGet, srv.URL, nil,
+		"Bearer tok", http.StatusOK,
+		"check your credentials", "Test", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "check your credentials") {
+		t.Errorf("error = %q, want it to contain %q", err, "check your credentials")
+	}
+}
+
+func TestAPIRequest_UnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	err := apiRequest(context.Background(), srv.Client(), http.MethodGet, srv.URL, nil,
+		"Bearer tok", http.StatusOK, "", "TestProvider", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "TestProvider API returned status 500") {
+		t.Errorf("error = %q, want it to contain status message", err)
+	}
+}
+
+func TestAPIRequest_DecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	var result struct{ Name string }
+	err := apiRequest(context.Background(), srv.Client(), http.MethodGet, srv.URL, nil,
+		"Bearer tok", http.StatusOK, "", "Test", &result)
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Errorf("error = %q, want it to contain 'failed to parse'", err)
+	}
+}
+
+func TestAPIRequest_PostSetsContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", got, "application/json")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	body := strings.NewReader(`{"key":"value"}`)
+	err := apiRequest(context.Background(), srv.Client(), http.MethodPost, srv.URL, body,
+		"rawkey", http.StatusOK, "", "Test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/model/session.go
+++ b/internal/model/session.go
@@ -67,3 +67,12 @@ func (s *Session) GetIssueRef() *IssueRef {
 func (s *Session) HasIssue() bool {
 	return s.GetIssueRef() != nil
 }
+
+// GetWorkDir returns the effective working directory for this session.
+// It prefers the worktree path if set, falling back to the repo path.
+func (s *Session) GetWorkDir() string {
+	if s.WorkTree != "" {
+		return s.WorkTree
+	}
+	return s.RepoPath
+}

--- a/internal/model/session_test.go
+++ b/internal/model/session_test.go
@@ -41,6 +41,26 @@ func TestSession_GetIssueRef_ZeroIssueNumber(t *testing.T) {
 	}
 }
 
+func TestSession_GetWorkDir(t *testing.T) {
+	tests := []struct {
+		name string
+		sess Session
+		want string
+	}{
+		{"worktree set", Session{RepoPath: "/repo", WorkTree: "/worktree"}, "/worktree"},
+		{"worktree empty", Session{RepoPath: "/repo"}, "/repo"},
+		{"both empty", Session{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sess.GetWorkDir(); got != tt.want {
+				t.Errorf("GetWorkDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSession_HasIssue(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- **`Session.GetWorkDir()`** — replaces 9 instances of the 3-line worktree-fallback pattern across `actions.go`, `coding.go`, `github_ops.go`, and `git_validate.go`
- **Timeout constants** (`timeouts.go`) — replaces ~37 magic duration literals across 9 daemon files with 7 named constants (`timeoutQuickAPI`, `timeoutStandardOp`, `timeoutGitHubMerge`, `timeoutGitPush`, `timeoutPRDescription`, `timeoutGitRewrite`, `timeoutDockerHealth`)
- **`Daemon.getSessionOrError()`** — replaces 16 session nil-check + error-return sites in `actions.go`, `github_ops.go`, `git_validate.go`, `host.go`, and `coding.go`
- **Shared `apiRequest()`** in issues package — consolidates HTTP boilerplate (request creation, auth headers, status checks, 403 handling, JSON decoding) across Asana (6 call sites) and Linear providers; rewrites `linearGraphQL` to use it and routes `FetchIssues`/`FetchTeams` through `linearGraphQL`

Net: -350 lines added / +448 lines = ~180 fewer lines of copy-paste boilerplate.

## Test plan

- [x] `go build -o erg .`
- [x] `go test -p=1 -count=1 ./...` — all packages pass
- [x] New table-driven tests for `GetWorkDir()`, `getSessionOrError()`, and `apiRequest()` (success, 403, unexpected status, decode error, header verification)
- [x] No test file timeouts modified — test durations remain as literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)