### PR TITLE
feat: add erg setup wizard command

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zhubert/erg/internal/cli"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Interactive setup wizard for erg",
+	Long: `Walks you through configuring erg:
+
+  - Checks required tools (git, claude, gh) and shows install instructions
+  - Guides you through setting up your issue tracker (GitHub, Asana, or Linear)
+  - Shows how to configure environment variables and workflow settings`,
+	RunE: runSetup,
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	return runSetupWithIO(os.Stdin, os.Stdout, cli.CheckAll)
+}
+
+// prereqCheckerFn is the type for the prerequisite check function.
+type prereqCheckerFn func([]cli.Prerequisite) []cli.CheckResult
+
+func runSetupWithIO(input io.Reader, output io.Writer, checker prereqCheckerFn) error {
+	fmt.Fprintln(output, "=== erg setup ===")
+	fmt.Fprintln(output)
+	fmt.Fprintln(output, "Checking prerequisites...")
+	fmt.Fprintln(output)
+
+	prereqs := cli.DefaultPrerequisites()
+	results := checker(prereqs)
+
+	anyRequiredMissing := false
+	for _, r := range results {
+		var status string
+		switch {
+		case r.Found:
+			status = "✓"
+		case r.Prerequisite.Required:
+			status = "✗"
+			anyRequiredMissing = true
+		default:
+			status = "○"
+		}
+
+		line := fmt.Sprintf("  %s %s", status, r.Prerequisite.Name)
+		if r.Found && r.Version != "" {
+			line += fmt.Sprintf(" (%s)", r.Version)
+		} else if !r.Found {
+			line += " [not found]"
+		}
+		fmt.Fprintln(output, line)
+	}
+
+	fmt.Fprintln(output)
+
+	if anyRequiredMissing {
+		fmt.Fprintln(output, "Some required tools are missing. Install them to continue:")
+		fmt.Fprintln(output)
+		for _, r := range results {
+			if !r.Found && r.Prerequisite.Required {
+				fmt.Fprintf(output, "  %s — %s\n", r.Prerequisite.Name, r.Prerequisite.Description)
+				fmt.Fprintf(output, "    Install: %s\n", r.Prerequisite.InstallURL)
+				fmt.Fprintln(output)
+			}
+		}
+		fmt.Fprintln(output, "After installing, run `erg setup` again.")
+		return nil
+	}
+
+	fmt.Fprintln(output, "All prerequisites installed!")
+	fmt.Fprintln(output)
+
+	fmt.Fprintln(output, "Which issue tracker would you like to use?")
+	fmt.Fprintln(output)
+	fmt.Fprintln(output, "  1. GitHub Issues  (uses gh CLI — no extra credentials needed)")
+	fmt.Fprintln(output, "  2. Asana Tasks    (requires ASANA_PAT environment variable)")
+	fmt.Fprintln(output, "  3. Linear Issues  (requires LINEAR_API_KEY environment variable)")
+	fmt.Fprintln(output)
+	fmt.Fprint(output, "Enter choice [1-3]: ")
+
+	scanner := bufio.NewScanner(input)
+	var choice string
+	if scanner.Scan() {
+		choice = strings.TrimSpace(scanner.Text())
+	}
+
+	fmt.Fprintln(output)
+
+	switch choice {
+	case "1":
+		printGitHubSetup(output)
+	case "2":
+		printAsanaSetup(output)
+	case "3":
+		printLinearSetup(output)
+	default:
+		fmt.Fprintf(output, "Invalid choice %q. Please run `erg setup` again and enter 1, 2, or 3.\n", choice)
+	}
+
+	return nil
+}
+
+func printGitHubSetup(w io.Writer) {
+	fmt.Fprintln(w, "=== GitHub Issues Setup ===")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "GitHub Issues is the default issue tracker for erg.")
+	fmt.Fprintln(w, "It uses the gh CLI (which you already have installed).")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Steps to get started:")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  1. Authenticate with GitHub:")
+	fmt.Fprintln(w, "       gh auth login")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  2. Label issues with \"queued\" for erg to pick them up.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  3. Initialize your workflow config (from within your repo):")
+	fmt.Fprintln(w, "       erg workflow init")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  4. Start the daemon:")
+	fmt.Fprintln(w, "       erg start")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Your erg setup is complete!")
+}
+
+func printAsanaSetup(w io.Writer) {
+	fmt.Fprintln(w, "=== Asana Tasks Setup ===")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "To use Asana Tasks, you need a Personal Access Token (PAT).")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Steps to get your PAT:")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  1. Log in at https://app.asana.com")
+	fmt.Fprintln(w, "  2. Click your profile icon → My Settings → Apps")
+	fmt.Fprintln(w, "  3. Under \"Personal Access Tokens\", click \"+ New Access Token\"")
+	fmt.Fprintln(w, "  4. Give it a name (e.g., \"erg\") and copy the token")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Add the token to your shell profile (~/.zshrc or ~/.bashrc):")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  export ASANA_PAT=\"your-token-here\"")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  # Reload your shell:")
+	fmt.Fprintln(w, "  source ~/.zshrc")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Configure your workflow (.erg/workflow.yaml):")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  source:")
+	fmt.Fprintln(w, "    provider: asana")
+	fmt.Fprintln(w, "    filter:")
+	fmt.Fprintln(w, "      project: \"YOUR_PROJECT_GID\"  # from the project URL")
+	fmt.Fprintln(w, "      label: queued              # Asana tag to filter on")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  # Find your project GID in the Asana project URL:")
+	fmt.Fprintln(w, "  # https://app.asana.com/0/PROJECT_GID/list")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Next steps:")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  1. Set ASANA_PAT in your environment")
+	fmt.Fprintln(w, "  2. Run: erg workflow init  (from within your repo)")
+	fmt.Fprintln(w, "  3. Set your Asana project GID in .erg/workflow.yaml")
+	fmt.Fprintln(w, "  4. Start the daemon: erg start")
+}
+
+func printLinearSetup(w io.Writer) {
+	fmt.Fprintln(w, "=== Linear Issues Setup ===")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "To use Linear Issues, you need an API key.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Steps to get your API key:")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  1. Log in at https://linear.app")
+	fmt.Fprintln(w, "  2. Go to Settings → API → Personal API Keys")
+	fmt.Fprintln(w, "  3. Click \"New API key\", give it a name (e.g., \"erg\"), and copy the key")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Add the key to your shell profile (~/.zshrc or ~/.bashrc):")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  export LINEAR_API_KEY=\"your-key-here\"")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  # Reload your shell:")
+	fmt.Fprintln(w, "  source ~/.zshrc")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Configure your workflow (.erg/workflow.yaml):")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  source:")
+	fmt.Fprintln(w, "    provider: linear")
+	fmt.Fprintln(w, "    filter:")
+	fmt.Fprintln(w, "      team: \"YOUR_TEAM_ID\"  # Linear team ID")
+	fmt.Fprintln(w, "      label: queued        # Linear label to filter on")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  # Find your team ID in Linear: Settings → API → or in the team URL.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Next steps:")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  1. Set LINEAR_API_KEY in your environment")
+	fmt.Fprintln(w, "  2. Run: erg workflow init  (from within your repo)")
+	fmt.Fprintln(w, "  3. Set your Linear team ID in .erg/workflow.yaml")
+	fmt.Fprintln(w, "  4. Start the daemon: erg start")
+}

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,0 +1,239 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/zhubert/erg/internal/cli"
+)
+
+// allFoundChecker returns a checker where every prerequisite is found.
+func allFoundChecker(prereqs []cli.Prerequisite) []cli.CheckResult {
+	results := make([]cli.CheckResult, len(prereqs))
+	for i, p := range prereqs {
+		results[i] = cli.CheckResult{
+			Prerequisite: p,
+			Found:        true,
+			Version:      p.Name + " version 1.0",
+		}
+	}
+	return results
+}
+
+// noneFoundChecker returns a checker where no prerequisite is found.
+func noneFoundChecker(prereqs []cli.Prerequisite) []cli.CheckResult {
+	results := make([]cli.CheckResult, len(prereqs))
+	for i, p := range prereqs {
+		results[i] = cli.CheckResult{
+			Prerequisite: p,
+			Found:        false,
+		}
+	}
+	return results
+}
+
+// partialChecker returns a checker with specific tools found by name.
+func partialChecker(found map[string]bool) prereqCheckerFn {
+	return func(prereqs []cli.Prerequisite) []cli.CheckResult {
+		results := make([]cli.CheckResult, len(prereqs))
+		for i, p := range prereqs {
+			results[i] = cli.CheckResult{
+				Prerequisite: p,
+				Found:        found[p.Name],
+			}
+			if found[p.Name] {
+				results[i].Version = p.Name + " version 1.0"
+			}
+		}
+		return results
+	}
+}
+
+func TestRunSetup_AllPrereqsMissing(t *testing.T) {
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader(""), &out, noneFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Some required tools are missing") {
+		t.Errorf("expected missing tools message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "erg setup") {
+		t.Errorf("expected retry instruction, got:\n%s", output)
+	}
+	// Should not reach the issue tracker prompt
+	if strings.Contains(output, "Which issue tracker") {
+		t.Errorf("should not show issue tracker prompt when prereqs are missing, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_RequiredMissing_ShowsInstallURLs(t *testing.T) {
+	checker := partialChecker(map[string]bool{"git": false, "claude": false, "gh": true})
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader(""), &out, checker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "https://git-scm.com") {
+		t.Errorf("expected git install URL, got:\n%s", output)
+	}
+	if !strings.Contains(output, "https://claude.ai/code") {
+		t.Errorf("expected claude install URL, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_AllPresent_ShowsTrackerMenu(t *testing.T) {
+	var out bytes.Buffer
+	// Provide no input — will get invalid choice, but we just want to see the menu
+	err := runSetupWithIO(strings.NewReader("\n"), &out, allFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "All prerequisites installed") {
+		t.Errorf("expected success message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "GitHub Issues") {
+		t.Errorf("expected GitHub option in menu, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Asana Tasks") {
+		t.Errorf("expected Asana option in menu, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Linear Issues") {
+		t.Errorf("expected Linear option in menu, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_GitHub(t *testing.T) {
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader("1\n"), &out, allFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "GitHub Issues Setup") {
+		t.Errorf("expected GitHub setup header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "gh auth login") {
+		t.Errorf("expected gh auth login instruction, got:\n%s", output)
+	}
+	if !strings.Contains(output, "queued") {
+		t.Errorf("expected queued label mention, got:\n%s", output)
+	}
+	if !strings.Contains(output, "erg workflow init") {
+		t.Errorf("expected workflow init instruction, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_Asana(t *testing.T) {
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader("2\n"), &out, allFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Asana Tasks Setup") {
+		t.Errorf("expected Asana setup header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "ASANA_PAT") {
+		t.Errorf("expected ASANA_PAT env var mention, got:\n%s", output)
+	}
+	if !strings.Contains(output, "app.asana.com") {
+		t.Errorf("expected Asana URL, got:\n%s", output)
+	}
+	if !strings.Contains(output, "provider: asana") {
+		t.Errorf("expected workflow YAML snippet, got:\n%s", output)
+	}
+	if !strings.Contains(output, "PROJECT_GID") {
+		t.Errorf("expected project GID placeholder, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_Linear(t *testing.T) {
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader("3\n"), &out, allFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Linear Issues Setup") {
+		t.Errorf("expected Linear setup header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "LINEAR_API_KEY") {
+		t.Errorf("expected LINEAR_API_KEY env var mention, got:\n%s", output)
+	}
+	if !strings.Contains(output, "linear.app") {
+		t.Errorf("expected Linear URL, got:\n%s", output)
+	}
+	if !strings.Contains(output, "provider: linear") {
+		t.Errorf("expected workflow YAML snippet, got:\n%s", output)
+	}
+	if !strings.Contains(output, "TEAM_ID") {
+		t.Errorf("expected team ID placeholder, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_InvalidChoice(t *testing.T) {
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader("5\n"), &out, allFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Invalid choice") {
+		t.Errorf("expected invalid choice message, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_EmptyInput(t *testing.T) {
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader(""), &out, allFoundChecker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Invalid choice") {
+		t.Errorf("expected invalid choice message for empty input, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_PrereqStatusSymbols(t *testing.T) {
+	// git found (required), claude found (required), gh not found (optional)
+	checker := partialChecker(map[string]bool{"git": true, "claude": true, "gh": false})
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader("\n"), &out, checker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "✓ git") {
+		t.Errorf("expected ✓ for git, got:\n%s", output)
+	}
+	if !strings.Contains(output, "✓ claude") {
+		t.Errorf("expected ✓ for claude, got:\n%s", output)
+	}
+	// gh is optional and not found — should show ○
+	if !strings.Contains(output, "○ gh") {
+		t.Errorf("expected ○ for optional gh, got:\n%s", output)
+	}
+	// All required tools present, so should proceed to tracker menu
+	if !strings.Contains(output, "All prerequisites installed") {
+		t.Errorf("expected success message when required tools present, got:\n%s", output)
+	}
+}
+
+func TestRunSetup_RequiredMissingSymbol(t *testing.T) {
+	checker := partialChecker(map[string]bool{"git": false, "claude": true, "gh": true})
+	var out bytes.Buffer
+	err := runSetupWithIO(strings.NewReader(""), &out, checker)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "✗ git") {
+		t.Errorf("expected ✗ for missing required git, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary
Adds an interactive `erg setup` CLI command that walks users through initial configuration — checking prerequisites, selecting an issue tracker, and displaying provider-specific setup instructions.

## Changes
- Add `cmd/setup.go` with the `erg setup` command and setup wizard logic
  - Checks required tools (git, claude, gh) with status symbols (✓/✗/○)
  - Prompts user to choose an issue tracker (GitHub Issues, Asana, Linear)
  - Displays provider-specific setup instructions including env vars, workflow config, and next steps
  - Uses dependency injection (`runSetupWithIO`) for testability
- Add `cmd/setup_test.go` with comprehensive tests covering:
  - All prereqs missing, partially missing, and all present
  - Each issue tracker selection (GitHub, Asana, Linear)
  - Invalid and empty input handling
  - Status symbol rendering for required vs optional tools

## Test plan
- Run `go test -p=1 -count=1 ./cmd/...` to verify all setup tests pass
- Run `erg setup` manually to walk through the wizard interactively

Fixes #236