### PR TITLE
fix(events): support Asana and Linear in gate.approved and plan.user_replied

### DIFF
--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -4,6 +4,7 @@ package issues
 
 import (
 	"context"
+	"time"
 )
 
 // Source identifies the origin of an issue (GitHub, Asana, Linear, etc.)
@@ -110,4 +111,22 @@ func (r *ProviderRegistry) GetProvider(source Source) Provider {
 // AllProviders returns all registered providers.
 func (r *ProviderRegistry) AllProviders() []Provider {
 	return r.providers
+}
+
+// IssueComment represents a comment on an issue from any supported source.
+type IssueComment struct {
+	Author    string    // Username or display name
+	Body      string    // Comment text
+	CreatedAt time.Time // When the comment was posted
+}
+
+// ProviderGateChecker extends Provider with operations needed for gate/approval events.
+// Providers that support label checking and comment fetching implement this interface,
+// enabling gate.approved and plan.user_replied events to work across all sources.
+type ProviderGateChecker interface {
+	// CheckIssueHasLabel returns true if the issue/task currently has the given label or tag.
+	CheckIssueHasLabel(ctx context.Context, repoPath string, issueID string, label string) (bool, error)
+
+	// GetIssueComments returns all comments on the issue/task, ordered oldest first.
+	GetIssueComments(ctx context.Context, repoPath string, issueID string) ([]IssueComment, error)
 }


### PR DESCRIPTION
## Summary
Extends the `gate.approved` and `plan.user_replied` workflow events to work with Asana and Linear issue sources, not just GitHub. Previously these events silently skipped non-GitHub issues.

## Changes
- Add `ProviderGateChecker` interface in `internal/issues/provider.go` with `CheckIssueHasLabel` and `GetIssueComments` methods
- Add `IssueComment` struct as a source-agnostic comment representation
- Implement `ProviderGateChecker` on `AsanaProvider` (via task tags and stories API)
- Implement `ProviderGateChecker` on `LinearProvider` (via GraphQL labels and comments queries)
- Refactor `checkGateApproved` and `checkPlanUserReplied` in `internal/daemon/events.go` to delegate to provider-agnostic `issueHasLabel` and `issueComments` helpers
- Remove GitHub-only guard clauses that caused these events to silently no-op for other sources
- Label matching is case-insensitive for both Asana and Linear

## Test plan
- Run `go test -p=1 -count=1 ./...`
- New unit tests cover:
  - Asana: `CheckIssueHasLabel` (found, not found, case-insensitive, no PAT)
  - Asana: `GetIssueComments` (returns comments, filters system stories and empty bodies, no PAT)
  - Linear: `CheckIssueHasLabel` (found, not found, case-insensitive, no API key)
  - Linear: `GetIssueComments` (returns comments, excludes empty bodies, no API key)
  - Daemon-level: `gate.approved` with Asana/Linear (label_added, comment_match triggers)
  - Daemon-level: `plan.user_replied` with Asana/Linear
  - Graceful fallback when no provider is registered for a source

Fixes #241