### PR TITLE
feat: rename 'erg setup' to 'erg configure'

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -12,27 +12,27 @@ import (
 	"github.com/zhubert/erg/internal/workflow"
 )
 
-var setupCmd = &cobra.Command{
-	Use:   "setup",
-	Short: "Interactive setup wizard for erg",
+var configureCmd = &cobra.Command{
+	Use:   "configure",
+	Short: "Interactive configuration wizard for erg",
 	Long: `Walks you through configuring erg:
 
   - Checks required tools (git, claude, gh) and shows install instructions
   - Guides you through setting up your issue tracker (GitHub, Asana, or Linear)
   - Asks workflow questions and generates .erg/workflow.yaml for your repo`,
-	RunE: runSetup,
+	RunE: runConfigure,
 }
 
 func init() {
-	rootCmd.AddCommand(setupCmd)
+	rootCmd.AddCommand(configureCmd)
 }
 
-func runSetup(cmd *cobra.Command, args []string) error {
+func runConfigure(cmd *cobra.Command, args []string) error {
 	repoPath, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
-	return runSetupWithIO(os.Stdin, os.Stdout, cli.CheckAll, repoPath, workflow.WriteFromWizard)
+	return runConfigureWithIO(os.Stdin, os.Stdout, cli.CheckAll, repoPath, workflow.WriteFromWizard)
 }
 
 // prereqCheckerFn is the type for the prerequisite check function.
@@ -41,8 +41,8 @@ type prereqCheckerFn func([]cli.Prerequisite) []cli.CheckResult
 // workflowWriterFn is a function that writes a workflow config based on wizard answers.
 type workflowWriterFn func(repoPath string, cfg workflow.WizardConfig) (string, error)
 
-func runSetupWithIO(input io.Reader, output io.Writer, checker prereqCheckerFn, repoPath string, writer workflowWriterFn) error {
-	fmt.Fprintln(output, "=== erg setup ===")
+func runConfigureWithIO(input io.Reader, output io.Writer, checker prereqCheckerFn, repoPath string, writer workflowWriterFn) error {
+	fmt.Fprintln(output, "=== erg configure ===")
 	fmt.Fprintln(output)
 	fmt.Fprintln(output, "Checking prerequisites...")
 	fmt.Fprintln(output)
@@ -84,7 +84,7 @@ func runSetupWithIO(input io.Reader, output io.Writer, checker prereqCheckerFn, 
 				fmt.Fprintln(output)
 			}
 		}
-		fmt.Fprintln(output, "After installing, run `erg setup` again.")
+		fmt.Fprintln(output, "After installing, run `erg configure` again.")
 		return nil
 	}
 
@@ -119,7 +119,7 @@ func runSetupWithIO(input io.Reader, output io.Writer, checker prereqCheckerFn, 
 		printLinearSetup(output)
 		provider = "linear"
 	default:
-		fmt.Fprintf(output, "Invalid choice %q. Please run `erg setup` again and enter 1, 2, or 3.\n", choice)
+		fmt.Fprintf(output, "Invalid choice %q. Please run `erg configure` again and enter 1, 2, or 3.\n", choice)
 		return nil
 	}
 
@@ -131,7 +131,7 @@ func runSetupWithIO(input io.Reader, output io.Writer, checker prereqCheckerFn, 
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			fmt.Fprintf(output, "Note: %s already exists, skipping workflow generation.\n", fp)
-			fmt.Fprintln(output, "      Delete it and run `erg setup` again to reconfigure.")
+			fmt.Fprintln(output, "      Delete it and run `erg configure` again to reconfigure.")
 		} else {
 			fmt.Fprintf(output, "Failed to write workflow config: %v\n", err)
 			return nil

--- a/cmd/configure_test.go
+++ b/cmd/configure_test.go
@@ -65,9 +65,9 @@ func captureWriter(captured *workflow.WizardConfig) workflowWriterFn {
 	}
 }
 
-func TestRunSetup_AllPrereqsMissing(t *testing.T) {
+func TestRunConfigure_AllPrereqsMissing(t *testing.T) {
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(""), &out, noneFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader(""), &out, noneFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestRunSetup_AllPrereqsMissing(t *testing.T) {
 	if !strings.Contains(output, "Some required tools are missing") {
 		t.Errorf("expected missing tools message, got:\n%s", output)
 	}
-	if !strings.Contains(output, "erg setup") {
+	if !strings.Contains(output, "erg configure") {
 		t.Errorf("expected retry instruction, got:\n%s", output)
 	}
 	// Should not reach the issue tracker prompt
@@ -84,10 +84,10 @@ func TestRunSetup_AllPrereqsMissing(t *testing.T) {
 	}
 }
 
-func TestRunSetup_RequiredMissing_ShowsInstallURLs(t *testing.T) {
+func TestRunConfigure_RequiredMissing_ShowsInstallURLs(t *testing.T) {
 	checker := partialChecker(map[string]bool{"git": false, "claude": false, "gh": true})
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(""), &out, checker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader(""), &out, checker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -100,10 +100,10 @@ func TestRunSetup_RequiredMissing_ShowsInstallURLs(t *testing.T) {
 	}
 }
 
-func TestRunSetup_AllPresent_ShowsTrackerMenu(t *testing.T) {
+func TestRunConfigure_AllPresent_ShowsTrackerMenu(t *testing.T) {
 	var out bytes.Buffer
 	// Provide no input — will get invalid choice, but we just want to see the menu
-	err := runSetupWithIO(strings.NewReader("\n"), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("\n"), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -122,10 +122,10 @@ func TestRunSetup_AllPresent_ShowsTrackerMenu(t *testing.T) {
 	}
 }
 
-func TestRunSetup_GitHub(t *testing.T) {
+func TestRunConfigure_GitHub(t *testing.T) {
 	var out bytes.Buffer
 	// Input: tracker choice "1", then wizard defaults (all empty → use defaults)
-	err := runSetupWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,12 +147,12 @@ func TestRunSetup_GitHub(t *testing.T) {
 	}
 }
 
-func TestRunSetup_GitHub_WizardCaptures(t *testing.T) {
+func TestRunConfigure_GitHub_WizardCaptures(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: tracker=1, label=myqueue, plan=y, fixci=n, autoreview=n, reviewer=alice, method=squash, containers=y, slack=n
 	input := "1\nmyqueue\ny\nn\nn\nalice\nsquash\ny\nn\n"
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,11 +183,11 @@ func TestRunSetup_GitHub_WizardCaptures(t *testing.T) {
 	}
 }
 
-func TestRunSetup_GitHub_WizardDefaults(t *testing.T) {
+func TestRunConfigure_GitHub_WizardDefaults(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: just tracker choice; wizard gets all defaults via EOF
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -212,9 +212,9 @@ func TestRunSetup_GitHub_WizardDefaults(t *testing.T) {
 	}
 }
 
-func TestRunSetup_Asana(t *testing.T) {
+func TestRunConfigure_Asana(t *testing.T) {
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("2\n"), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("2\n"), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,13 +233,13 @@ func TestRunSetup_Asana(t *testing.T) {
 	}
 }
 
-func TestRunSetup_Asana_WizardCaptures(t *testing.T) {
+func TestRunConfigure_Asana_WizardCaptures(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: tracker=2, project=1234, org=1(tags), tag=ready, section=(skip), completion=Done,
 	// plan=n, fixci=y, autoreview=y, reviewer=, method=, containers=n, slack=n
 	input := "2\n1234\n1\nready\n\nDone\nn\ny\ny\n\n\nn\nn\n"
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -261,9 +261,9 @@ func TestRunSetup_Asana_WizardCaptures(t *testing.T) {
 	}
 }
 
-func TestRunSetup_Linear(t *testing.T) {
+func TestRunConfigure_Linear(t *testing.T) {
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("3\n"), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("3\n"), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -282,12 +282,12 @@ func TestRunSetup_Linear(t *testing.T) {
 	}
 }
 
-func TestRunSetup_Linear_WizardCaptures(t *testing.T) {
+func TestRunConfigure_Linear_WizardCaptures(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: tracker=3, team=team-xyz, org=1(labels), label=queued, completionState=Merged, then defaults
 	input := "3\nteam-xyz\n1\n\nMerged\n"
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -309,9 +309,9 @@ func TestRunSetup_Linear_WizardCaptures(t *testing.T) {
 	}
 }
 
-func TestRunSetup_InvalidChoice(t *testing.T) {
+func TestRunConfigure_InvalidChoice(t *testing.T) {
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("5\n"), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("5\n"), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -321,9 +321,9 @@ func TestRunSetup_InvalidChoice(t *testing.T) {
 	}
 }
 
-func TestRunSetup_EmptyInput(t *testing.T) {
+func TestRunConfigure_EmptyInput(t *testing.T) {
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(""), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader(""), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -333,11 +333,11 @@ func TestRunSetup_EmptyInput(t *testing.T) {
 	}
 }
 
-func TestRunSetup_PrereqStatusSymbols(t *testing.T) {
+func TestRunConfigure_PrereqStatusSymbols(t *testing.T) {
 	// git found (required), claude found (required), gh not found (optional)
 	checker := partialChecker(map[string]bool{"git": true, "claude": true, "gh": false})
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("\n"), &out, checker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("\n"), &out, checker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -358,10 +358,10 @@ func TestRunSetup_PrereqStatusSymbols(t *testing.T) {
 	}
 }
 
-func TestRunSetup_RequiredMissingSymbol(t *testing.T) {
+func TestRunConfigure_RequiredMissingSymbol(t *testing.T) {
 	checker := partialChecker(map[string]bool{"git": false, "claude": true, "gh": true})
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(""), &out, checker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader(""), &out, checker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -371,14 +371,14 @@ func TestRunSetup_RequiredMissingSymbol(t *testing.T) {
 	}
 }
 
-func TestRunSetup_WorkflowFileAlreadyExists(t *testing.T) {
+func TestRunConfigure_WorkflowFileAlreadyExists(t *testing.T) {
 	existsWriter := func(repoPath string, cfg workflow.WizardConfig) (string, error) {
 		fp := filepath.Join(repoPath, ".erg", "workflow.yaml")
 		return fp, &alreadyExistsError{fp: fp}
 	}
 
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", existsWriter)
+	err := runConfigureWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", existsWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -386,15 +386,15 @@ func TestRunSetup_WorkflowFileAlreadyExists(t *testing.T) {
 	if !strings.Contains(output, "already exists") {
 		t.Errorf("expected 'already exists' message, got:\n%s", output)
 	}
-	// Should still show erg start since setup is otherwise complete
+	// Should still show erg start since configure is otherwise complete
 	if !strings.Contains(output, "erg start") {
 		t.Errorf("expected erg start instruction even when file exists, got:\n%s", output)
 	}
 }
 
-func TestRunSetup_ShowsErgStart(t *testing.T) {
+func TestRunConfigure_ShowsErgStart(t *testing.T) {
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", noopWriter)
+	err := runConfigureWithIO(strings.NewReader("1\n"), &out, allFoundChecker, ".", noopWriter)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -407,13 +407,13 @@ func TestRunSetup_ShowsErgStart(t *testing.T) {
 	}
 }
 
-func TestRunSetup_Asana_Kanban_WizardCaptures(t *testing.T) {
+func TestRunConfigure_Asana_Kanban_WizardCaptures(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: tracker=2, project=1234, org=2(kanban), section="To do"(default), completion="Done"(default),
 	// plan=n, fixci=y, autoreview=y, reviewer=, method=, containers=n, slack=n
 	input := "2\n1234\n2\n\n\nn\ny\ny\n\n\nn\nn\n"
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -435,13 +435,13 @@ func TestRunSetup_Asana_Kanban_WizardCaptures(t *testing.T) {
 	}
 }
 
-func TestRunSetup_Linear_Kanban_WizardCaptures(t *testing.T) {
+func TestRunConfigure_Linear_Kanban_WizardCaptures(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: tracker=3, team=team-xyz, org=2(kanban), label=queued(default), completion="Done"(default),
 	// plan=n, fixci=y, autoreview=y, reviewer=, method=, containers=n, slack=n
 	input := "3\nteam-xyz\n2\n\n\nn\ny\ny\n\n\nn\nn\n"
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -460,13 +460,13 @@ func TestRunSetup_Linear_Kanban_WizardCaptures(t *testing.T) {
 	}
 }
 
-func TestRunSetup_GitHub_Slack_WizardCaptures(t *testing.T) {
+func TestRunConfigure_GitHub_Slack_WizardCaptures(t *testing.T) {
 	var captured workflow.WizardConfig
 	// Input: tracker=1, label=queued(default), plan=n, fixci=y, autoreview=y, reviewer=, method=, containers=n,
 	// slack=y, webhook=$SLACK_WEBHOOK_URL
 	input := "1\n\nn\ny\ny\n\n\nn\ny\n$SLACK_WEBHOOK_URL\n"
 	var out bytes.Buffer
-	err := runSetupWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
+	err := runConfigureWithIO(strings.NewReader(input), &out, allFoundChecker, ".", captureWriter(&captured))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1421,14 +1421,14 @@
 
         <h3 id="quickstart">Quick start</h3>
         <p>
-          Run <code>erg setup</code> inside your repo. It will walk you through
+          Run <code>erg configure</code> inside your repo. It will walk you through
           choosing an issue provider (GitHub, Asana, or Linear), configuring
           credentials, and scaffolding a workflow — then start the daemon.
         </p>
         <div class="install-block">
           <span class="prompt-char">$</span>
-          <code>erg setup</code>
-          <button class="copy-btn" onclick="copyCmd(this, 'erg setup')">
+          <code>erg configure</code>
+          <button class="copy-btn" onclick="copyCmd(this, 'erg configure')">
             copy
           </button>
         </div>


### PR DESCRIPTION
## Summary
Renames the `erg setup` CLI command to `erg configure` for clearer intent — the command configures an existing repo rather than performing a one-time setup.

## Changes
- Renamed `cmd/setup.go` to `cmd/configure.go` and updated the command registration, function names, and user-facing strings
- Renamed `cmd/setup_test.go` to `cmd/configure_test.go` and updated all test function names and assertions
- Updated the landing page docs (`docs/index.html`) to reference `erg configure`

## Test plan
- `go test -p=1 -count=1 ./cmd/...` — all renamed tests pass
- Run `go build -o erg . && ./erg configure --help` to confirm the new command name is registered
- Verify `./erg setup` is no longer recognized

Fixes #252