### PR TITLE
feat(daemon): add marker-based idempotency for comment actions

### DIFF
--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -255,7 +255,7 @@ func (a *commentIssueAction) Execute(ctx context.Context, ac *workflow.ActionCon
 		return workflow.ActionResult{Error: fmt.Errorf("work item not found: %s", ac.WorkItemID)}
 	}
 
-	if err := d.commentOnIssue(ctx, item, ac.Params); err != nil {
+	if err := d.commentOnIssue(ctx, item, ac.Params, ac.Step); err != nil {
 		return workflow.ActionResult{Error: fmt.Errorf("issue comment failed: %w", err)}
 	}
 
@@ -275,7 +275,7 @@ func (a *commentPRAction) Execute(ctx context.Context, ac *workflow.ActionContex
 		return workflow.ActionResult{Error: fmt.Errorf("work item not found: %s", ac.WorkItemID)}
 	}
 
-	if err := d.commentOnPR(ctx, item, ac.Params); err != nil {
+	if err := d.commentOnPR(ctx, item, ac.Params, ac.Step); err != nil {
 		return workflow.ActionResult{Error: fmt.Errorf("PR comment failed: %w", err)}
 	}
 
@@ -295,7 +295,7 @@ func (a *asanaCommentAction) Execute(ctx context.Context, ac *workflow.ActionCon
 		return workflow.ActionResult{Error: fmt.Errorf("work item not found: %s", ac.WorkItemID)}
 	}
 
-	if err := d.commentViaProvider(ctx, item, ac.Params, issues.SourceAsana); err != nil {
+	if err := d.commentViaProvider(ctx, item, ac.Params, issues.SourceAsana, ac.Step); err != nil {
 		return workflow.ActionResult{Error: fmt.Errorf("asana comment failed: %w", err)}
 	}
 
@@ -335,7 +335,7 @@ func (a *linearCommentAction) Execute(ctx context.Context, ac *workflow.ActionCo
 		return workflow.ActionResult{Error: fmt.Errorf("work item not found: %s", ac.WorkItemID)}
 	}
 
-	if err := d.commentViaProvider(ctx, item, ac.Params, issues.SourceLinear); err != nil {
+	if err := d.commentViaProvider(ctx, item, ac.Params, issues.SourceLinear, ac.Step); err != nil {
 		return workflow.ActionResult{Error: fmt.Errorf("linear comment failed: %w", err)}
 	}
 

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -116,9 +116,20 @@ func (r *ProviderRegistry) AllProviders() []Provider {
 
 // IssueComment represents a comment on an issue from any supported source.
 type IssueComment struct {
+	ID        string    // Provider-specific comment identifier (for updates; empty if not supported)
 	Author    string    // Username or display name
 	Body      string    // Comment text
 	CreatedAt time.Time // When the comment was posted
+}
+
+// ProviderCommentUpdater extends ProviderActions with the ability to update
+// an existing comment by its provider-specific ID. This is used for idempotent
+// comment actions: if a comment with the matching marker already exists, it is
+// updated in place rather than creating a duplicate.
+type ProviderCommentUpdater interface {
+	// UpdateComment replaces the body of an existing comment identified by commentID.
+	// The commentID comes from IssueComment.ID returned by GetIssueComments.
+	UpdateComment(ctx context.Context, repoPath string, issueID string, commentID string, body string) error
 }
 
 // ProviderSectionChecker extends Provider with the ability to check which section

--- a/internal/workflow/actions.go
+++ b/internal/workflow/actions.go
@@ -18,6 +18,7 @@ type ActionContext struct {
 	SessionID  string
 	RepoPath   string
 	Branch     string
+	Step       string // current workflow state name, used as idempotency marker for comment actions
 	Params     *ParamHelper
 	Logger     *slog.Logger
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -126,6 +126,7 @@ func (e *Engine) processTaskState(ctx context.Context, item *WorkItemView, state
 		SessionID:  item.SessionID,
 		RepoPath:   item.RepoPath,
 		Branch:     item.Branch,
+		Step:       item.CurrentStep,
 		Params:     params,
 		Logger:     e.logger,
 		Extra:      item.Extra,


### PR DESCRIPTION
## Summary
Adds idempotent comment handling across all comment actions (GitHub issues, GitHub PRs, Asana, Linear). When a workflow step name is provided, comments are tagged with a marker and updated in place on re-execution instead of creating duplicates — mirroring the pattern used by CI bots like Vercel and Codecov.

## Changes
- Add `Step` field to `ActionContext`, populated from the current workflow state name
- Introduce `ergGitHubMarker` (HTML comment) and `ergProviderMarker` (bracket format) for GitHub and Asana/Linear respectively
- Implement upsert logic in `commentOnIssue`, `commentOnPR`, and `commentViaProvider` — list existing comments, find marker match, update or create
- Add `ListIssueComments`, `UpdateIssueComment`, and `GetPRNumber` methods to `GitService`
- Add `ProviderCommentUpdater` interface and implement `UpdateComment` on both `AsanaProvider` and `LinearProvider`
- Include comment `ID` field in `IssueComment` struct and populate it from Asana GID and Linear comment UUID
- When no step is set, original behavior (always create) is preserved with no marker

## Test plan
- Run `go test -p=1 -count=1 ./...`
- New unit tests cover:
  - Marker string generation (`TestErgGitHubMarker`, `TestErgProviderMarker`)
  - GitHub issue comment: idempotent create, idempotent update, no-step fallthrough
  - Provider comment (Asana/Linear): idempotent create, idempotent update, no-step fallthrough
  - `ListIssueComments`: success, empty, CLI error, invalid JSON
  - `UpdateIssueComment`: success, CLI error
  - `GetPRNumber`: success, CLI error, invalid JSON
  - Asana `UpdateComment`: success, missing PAT, server error
  - Linear `UpdateComment`: success, missing API key, server error
  - Engine populates `Step` in `ActionContext`