### PR TITLE
fix: make github.create_release idempotent

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -6667,6 +6667,11 @@ func TestCreateReleaseAction_Execute_Success(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
+	// Mock `gh release view` to return not-found (enabling idempotency check to proceed).
+	mockExec.AddExactMatch("gh", []string{"release", "view", "v1.0.0", "--json", "url"}, exec.MockResponse{
+		Err: fmt.Errorf("release not found"),
+	})
+
 	// Mock `gh release create` to succeed
 	mockExec.AddPrefixMatch("gh", []string{"release", "create", "v1.0.0"}, exec.MockResponse{
 		Stdout: []byte("https://github.com/owner/repo/releases/tag/v1.0.0\n"),
@@ -6717,6 +6722,11 @@ func TestCreateReleaseAction_Execute_Success(t *testing.T) {
 func TestCreateReleaseAction_Execute_GhError(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
+
+	// Mock `gh release view` to return not-found (enabling idempotency check to proceed).
+	mockExec.AddExactMatch("gh", []string{"release", "view", "v1.0.0", "--json", "url"}, exec.MockResponse{
+		Err: fmt.Errorf("release not found"),
+	})
 
 	// Mock `gh release create` to fail
 	mockExec.AddPrefixMatch("gh", []string{"release", "create"}, exec.MockResponse{

--- a/internal/git/github_test.go
+++ b/internal/git/github_test.go
@@ -2263,6 +2263,9 @@ func TestGetIssueComments_InvalidJSON(t *testing.T) {
 
 func TestCreateRelease_Success_GenerateNotes(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"release", "view", "v1.2.3", "--json", "url"}, pexec.MockResponse{
+		Err: fmt.Errorf("release not found"),
+	})
 	mock.AddExactMatch("gh", []string{"release", "create", "v1.2.3", "--generate-notes"}, pexec.MockResponse{
 		Stdout: []byte("https://github.com/owner/repo/releases/tag/v1.2.3\n"),
 	})
@@ -2279,6 +2282,9 @@ func TestCreateRelease_Success_GenerateNotes(t *testing.T) {
 
 func TestCreateRelease_Success_CustomNotes(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"release", "view", "v2.0.0", "--json", "url"}, pexec.MockResponse{
+		Err: fmt.Errorf("release not found"),
+	})
 	mock.AddExactMatch("gh", []string{"release", "create", "v2.0.0", "--title", "Version 2", "--notes", "Breaking changes."}, pexec.MockResponse{
 		Stdout: []byte("https://github.com/owner/repo/releases/tag/v2.0.0\n"),
 	})
@@ -2295,6 +2301,9 @@ func TestCreateRelease_Success_CustomNotes(t *testing.T) {
 
 func TestCreateRelease_Success_DraftPrerelease(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"release", "view", "v1.0.0-beta.1", "--json", "url"}, pexec.MockResponse{
+		Err: fmt.Errorf("release not found"),
+	})
 	mock.AddExactMatch("gh", []string{"release", "create", "v1.0.0-beta.1", "--generate-notes", "--draft", "--prerelease", "--target", "dev"}, pexec.MockResponse{
 		Stdout: []byte("https://github.com/owner/repo/releases/tag/v1.0.0-beta.1\n"),
 	})
@@ -2321,6 +2330,9 @@ func TestCreateRelease_EmptyTag(t *testing.T) {
 
 func TestCreateRelease_CLIError(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"release", "view", "v1.0.0", "--json", "url"}, pexec.MockResponse{
+		Err: fmt.Errorf("release not found"),
+	})
 	mock.AddExactMatch("gh", []string{"release", "create", "v1.0.0", "--generate-notes"}, pexec.MockResponse{
 		Err: fmt.Errorf("gh: tag already exists"),
 	})
@@ -2375,6 +2387,46 @@ func TestCreateRelease_ViewFails_ProceedsToCreate(t *testing.T) {
 	}
 	if url != "https://github.com/owner/repo/releases/tag/v1.0.0" {
 		t.Errorf("unexpected release URL: %s", url)
+	}
+}
+
+func TestCreateRelease_ViewFails_NonNotFoundError_ReturnsError(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"release", "view", "v1.0.0", "--json", "url"}, pexec.MockResponse{
+		Err: fmt.Errorf("HTTP 500: internal server error"),
+	})
+	// gh release create should NOT be called on non-not-found errors.
+
+	svc := NewGitServiceWithExecutor(mock)
+	_, err := svc.CreateRelease(context.Background(), "/repo", "v1.0.0", "", "", false, false, "")
+	if err == nil {
+		t.Fatal("expected error when gh release view fails with non-not-found error")
+	}
+	if !strings.Contains(err.Error(), "gh release view failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+
+	// Verify gh release create was never called.
+	for _, call := range mock.GetCalls() {
+		if call.Name == "gh" && len(call.Args) >= 2 && call.Args[0] == "release" && call.Args[1] == "create" {
+			t.Error("gh release create should not be called on view errors other than not-found")
+		}
+	}
+}
+
+func TestCreateRelease_ViewSuccess_InvalidJSON_ReturnsError(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"release", "view", "v1.0.0", "--json", "url"}, pexec.MockResponse{
+		Stdout: []byte("not valid json"),
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	_, err := svc.CreateRelease(context.Background(), "/repo", "v1.0.0", "", "", false, false, "")
+	if err == nil {
+		t.Fatal("expected error when gh release view returns invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "unexpected response from gh release view") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Makes `CreateRelease` idempotent by checking if a release already exists for the given tag before attempting to create a new one. This prevents errors when the release action is retried or re-executed.

## Changes
- Add a `gh release view` check before `gh release create` in `CreateRelease` — if the release already exists, return its URL immediately
- Add test for the idempotent path (release exists, returns existing URL, skips create)
- Add test for the fallback path (view fails, proceeds to create as before)

## Test plan
- `go test -p=1 -count=1 ./internal/git/...`
- New tests verify both paths: existing release returns early, missing release falls through to create