### PR TITLE
fix: make github.close_issue idempotent

### DIFF
--- a/internal/daemon/github_ops.go
+++ b/internal/daemon/github_ops.go
@@ -549,7 +549,19 @@ func (d *Daemon) moveToState(ctx context.Context, item daemonstate.WorkItem, par
 	return sm.MoveToSection(moveCtx, repoPath, item.IssueRef.ID, state)
 }
 
+// parseIssueState extracts the state string from `gh issue view --json state` output.
+func parseIssueState(data []byte) (string, error) {
+	var result struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", fmt.Errorf("parse issue state: %w", err)
+	}
+	return result.State, nil
+}
+
 // closeIssue closes the GitHub issue for a work item.
+// It is idempotent: if the issue is already closed, it returns nil.
 func (d *Daemon) closeIssue(ctx context.Context, item daemonstate.WorkItem) error {
 	if item.IssueRef.Source != "github" {
 		d.logger.Warn("github.close_issue skipped: not a github issue",
@@ -564,6 +576,17 @@ func (d *Daemon) closeIssue(ctx context.Context, item daemonstate.WorkItem) erro
 
 	closeCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
 	defer cancel()
+
+	// Check current state before closing to make this idempotent.
+	viewCmd := osexec.CommandContext(closeCtx, "gh", "issue", "view", item.IssueRef.ID, "--json", "state")
+	viewCmd.Dir = repoPath
+	if viewOutput, viewErr := viewCmd.Output(); viewErr == nil {
+		if state, parseErr := parseIssueState(viewOutput); parseErr == nil && strings.EqualFold(state, "CLOSED") {
+			d.logger.Debug("github.close_issue skipped: issue already closed",
+				"workItem", item.ID, "issue", item.IssueRef.ID)
+			return nil
+		}
+	}
 
 	cmd := osexec.CommandContext(closeCtx, "gh", "issue", "close", item.IssueRef.ID)
 	cmd.Dir = repoPath

--- a/internal/daemon/github_ops_test.go
+++ b/internal/daemon/github_ops_test.go
@@ -344,3 +344,51 @@ func TestParseReviewRequests(t *testing.T) {
 
 // Silence unused import warning for config (used in testSession from daemon_test.go).
 var _ = config.Session{}
+
+func TestParseIssueState(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantState string
+		wantErr   bool
+	}{
+		{
+			name:      "open issue",
+			input:     `{"state": "OPEN"}`,
+			wantState: "OPEN",
+		},
+		{
+			name:      "closed issue",
+			input:     `{"state": "CLOSED"}`,
+			wantState: "CLOSED",
+		},
+		{
+			name:    "invalid JSON",
+			input:   `not json`,
+			wantErr: true,
+		},
+		{
+			name:      "empty state",
+			input:     `{"state": ""}`,
+			wantState: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseIssueState([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantState {
+				t.Errorf("state = %q, want %q", got, tc.wantState)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Makes the `closeIssue` daemon action idempotent by checking whether the GitHub issue is already closed before attempting to close it, preventing errors on repeated invocations.

## Changes
- Add `parseIssueState` helper to extract state from `gh issue view --json state` output
- Check issue state before calling `gh issue close`; skip with a debug log if already closed
- Add table-driven tests for `parseIssueState`

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify new and existing tests pass
- Verify idempotent behavior: calling `closeIssue` on an already-closed issue should return nil without error