### PR TITLE
feat(daemon): derive conflict resolution round counter from git state

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -4192,9 +4192,19 @@ func TestResolveConflictsAction_NoSession(t *testing.T) {
 
 func TestResolveConflictsAction_MaxRoundsExceeded(t *testing.T) {
 	cfg := testConfig()
-	d := testDaemon(cfg)
+	mockExec := exec.NewMockExecutor(nil)
+
+	// CountMergeCommits: RemoteBranchExists → origin/main exists
+	mockExec.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, exec.MockResponse{})
+	// CountMergeCommits: git rev-list returns 3 (max already reached)
+	mockExec.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "origin/main..HEAD"}, exec.MockResponse{
+		Stdout: []byte("3\n"),
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
 
 	sess := testSession("sess-1")
+	sess.BaseBranch = "main"
 	cfg.AddSession(*sess)
 
 	d.state.AddWorkItem(&daemonstate.WorkItem{
@@ -4202,7 +4212,7 @@ func TestResolveConflictsAction_MaxRoundsExceeded(t *testing.T) {
 		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
 		SessionID: "sess-1",
 		Branch:    "feature-sess-1",
-		StepData:  map[string]any{"conflict_rounds": 3},
+		StepData:  map[string]any{},
 	})
 
 	action := &resolveConflictsAction{daemon: d}
@@ -4225,42 +4235,16 @@ func TestResolveConflictsAction_MaxRoundsExceeded(t *testing.T) {
 	}
 }
 
-func TestResolveConflictsAction_MaxRoundsFloat64(t *testing.T) {
-	cfg := testConfig()
-	d := testDaemon(cfg)
-
-	sess := testSession("sess-1")
-	cfg.AddSession(*sess)
-
-	d.state.AddWorkItem(&daemonstate.WorkItem{
-		ID:        "item-1",
-		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
-		SessionID: "sess-1",
-		Branch:    "feature-sess-1",
-		StepData:  map[string]any{"conflict_rounds": float64(3)},
-	})
-
-	action := &resolveConflictsAction{daemon: d}
-	params := workflow.NewParamHelper(map[string]any{"max_conflict_rounds": 3})
-	ac := &workflow.ActionContext{
-		WorkItemID: "item-1",
-		Params:     params,
-	}
-
-	result := action.Execute(context.Background(), ac)
-
-	if result.Success {
-		t.Error("expected failure when max rounds exceeded (float64)")
-	}
-	if result.Error == nil {
-		t.Error("expected error when max rounds exceeded (float64)")
-	}
-}
-
 func TestResolveConflictsAction_CleanMerge(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
+	// CountMergeCommits: RemoteBranchExists → origin/main exists
+	mockExec.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, exec.MockResponse{})
+	// CountMergeCommits: 0 completed rounds so far
+	mockExec.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "origin/main..HEAD"}, exec.MockResponse{
+		Stdout: []byte("0\n"),
+	})
 	// Mock IsMergeInProgress (git rev-parse --verify MERGE_HEAD fails = no merge)
 	mockExec.AddExactMatch("git", []string{"rev-parse", "--verify", "MERGE_HEAD"}, exec.MockResponse{
 		Err: fmt.Errorf("not found"),
@@ -4269,10 +4253,6 @@ func TestResolveConflictsAction_CleanMerge(t *testing.T) {
 	mockExec.AddExactMatch("git", []string{"fetch", "origin", "main"}, exec.MockResponse{})
 	// Mock git merge (clean)
 	mockExec.AddExactMatch("git", []string{"merge", "origin/main", "--no-edit"}, exec.MockResponse{})
-	// Mock GetDefaultBranch
-	mockExec.AddPrefixMatch("git", []string{"symbolic-ref"}, exec.MockResponse{
-		Stdout: []byte("refs/remotes/origin/main"),
-	})
 
 	d := testDaemonWithExec(cfg, mockExec)
 
@@ -4303,19 +4283,18 @@ func TestResolveConflictsAction_CleanMerge(t *testing.T) {
 	if result.Async {
 		t.Error("expected sync result for clean merge (no Claude needed)")
 	}
-
-	// Verify rounds incremented
-	item, _ := d.state.GetWorkItem("item-1")
-	rounds := getConflictRounds(item.StepData)
-	if rounds != 1 {
-		t.Errorf("expected conflict_rounds=1, got %d", rounds)
-	}
 }
 
 func TestResolveConflictsAction_ConflictsStartWorker(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
+	// CountMergeCommits: RemoteBranchExists → origin/main exists
+	mockExec.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, exec.MockResponse{})
+	// CountMergeCommits: 0 completed rounds so far
+	mockExec.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "origin/main..HEAD"}, exec.MockResponse{
+		Stdout: []byte("0\n"),
+	})
 	// Mock IsMergeInProgress (no stale merge)
 	mockExec.AddExactMatch("git", []string{"rev-parse", "--verify", "MERGE_HEAD"}, exec.MockResponse{
 		Err: fmt.Errorf("not found"),
@@ -4329,10 +4308,6 @@ func TestResolveConflictsAction_ConflictsStartWorker(t *testing.T) {
 	// Mock GetConflictedFiles
 	mockExec.AddExactMatch("git", []string{"diff", "--name-only", "--diff-filter=U"}, exec.MockResponse{
 		Stdout: []byte("file1.go\nfile2.go\n"),
-	})
-	// Mock GetDefaultBranch
-	mockExec.AddPrefixMatch("git", []string{"symbolic-ref"}, exec.MockResponse{
-		Stdout: []byte("refs/remotes/origin/main"),
 	})
 
 	d := testDaemonWithExec(cfg, mockExec)
@@ -4364,38 +4339,8 @@ func TestResolveConflictsAction_ConflictsStartWorker(t *testing.T) {
 	if !result.Async {
 		t.Error("expected async result when conflicts need Claude resolution")
 	}
-
-	// Verify rounds incremented
-	item, _ := d.state.GetWorkItem("item-1")
-	rounds := getConflictRounds(item.StepData)
-	if rounds != 1 {
-		t.Errorf("expected conflict_rounds=1, got %d", rounds)
-	}
 }
 
-func TestGetConflictRounds(t *testing.T) {
-	tests := []struct {
-		name     string
-		stepData map[string]any
-		expected int
-	}{
-		{"nil step data", nil, 0},
-		{"empty step data", map[string]any{}, 0},
-		{"int value", map[string]any{"conflict_rounds": 2}, 2},
-		{"float64 value (JSON)", map[string]any{"conflict_rounds": float64(3)}, 3},
-		{"string value (invalid)", map[string]any{"conflict_rounds": "2"}, 0},
-		{"zero value", map[string]any{"conflict_rounds": 0}, 0},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getConflictRounds(tt.stepData)
-			if got != tt.expected {
-				t.Errorf("expected %d, got %d", tt.expected, got)
-			}
-		})
-	}
-}
 
 func TestFormatConflictResolutionPrompt(t *testing.T) {
 	prompt := formatConflictResolutionPrompt(2, []string{"file1.go", "file2.go"})

--- a/internal/daemon/coding.go
+++ b/internal/daemon/coding.go
@@ -882,21 +882,6 @@ INSTRUCTIONS:
 DO NOT push — the system handles pushing after you commit.`, round, fileList)
 }
 
-// getConflictRounds extracts the conflict resolution round counter from step data.
-func getConflictRounds(stepData map[string]any) int {
-	v, ok := stepData["conflict_rounds"]
-	if !ok {
-		return 0
-	}
-	switch n := v.(type) {
-	case int:
-		return n
-	case float64:
-		return int(n)
-	default:
-		return 0
-	}
-}
 
 // getRebaseRounds extracts the rebase round counter from step data.
 func getRebaseRounds(stepData map[string]any) int {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3092,3 +3092,77 @@ func TestLoadTranscript_EmptyMessages(t *testing.T) {
 		t.Errorf("expected empty string for session with no messages, got %q", result)
 	}
 }
+
+func TestCountMergeCommits_ZeroRounds(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	// RemoteBranchExists: origin/main found
+	mock.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, pexec.MockResponse{})
+	// rev-list returns 0
+	mock.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "origin/main..HEAD"}, pexec.MockResponse{
+		Stdout: []byte("0\n"),
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	count, err := svc.CountMergeCommits(context.Background(), "/worktree", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 merge commits, got %d", count)
+	}
+}
+
+func TestCountMergeCommits_MultipleRounds(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, pexec.MockResponse{})
+	mock.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "origin/main..HEAD"}, pexec.MockResponse{
+		Stdout: []byte("2\n"),
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	count, err := svc.CountMergeCommits(context.Background(), "/worktree", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 merge commits, got %d", count)
+	}
+}
+
+func TestCountMergeCommits_FallsBackToLocalBranch(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	// RemoteBranchExists: origin/main not found
+	mock.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, pexec.MockResponse{
+		Err: fmt.Errorf("not found"),
+	})
+	// Falls back to local main
+	mock.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "main..HEAD"}, pexec.MockResponse{
+		Stdout: []byte("1\n"),
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	count, err := svc.CountMergeCommits(context.Background(), "/worktree", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 merge commit, got %d", count)
+	}
+}
+
+func TestCountMergeCommits_RevListError(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("git", []string{"rev-parse", "--verify", "origin/main"}, pexec.MockResponse{})
+	mock.AddExactMatch("git", []string{"rev-list", "--merges", "--count", "origin/main..HEAD"}, pexec.MockResponse{
+		Err: fmt.Errorf("git error"),
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	_, err := svc.CountMergeCommits(context.Background(), "/worktree", "main")
+	if err == nil {
+		t.Fatal("expected error from rev-list failure")
+	}
+	if !strings.Contains(err.Error(), "git rev-list") {
+		t.Errorf("expected rev-list error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Replace the mutable `conflict_rounds` step data counter with a deterministic count derived from git merge commits. Each completed conflict-resolution round leaves exactly one merge commit on the branch, so counting merge commits (`git rev-list --merges --count`) gives us the true round count without needing to maintain state.

## Changes
- Add `GitService.CountMergeCommits()` that counts merge commits between `origin/<base>..HEAD`, falling back to local branch ref if the remote isn't available
- Refactor `resolveConflictsAction` to derive round count from git state instead of reading/writing `conflict_rounds` in step data
- Remove `getConflictRounds()` helper and all step data mutation for conflict rounds
- Remove `TestGetConflictRounds` and `TestResolveConflictsAction_MaxRoundsFloat64` tests (no longer relevant)
- Update existing action tests to mock the new `CountMergeCommits` git calls
- Add unit tests for `CountMergeCommits`: zero rounds, multiple rounds, local branch fallback, and error handling

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify all tests pass
- Verify `TestCountMergeCommits_*` tests cover zero, multi-round, fallback, and error cases
- Verify `TestResolveConflictsAction_MaxRoundsExceeded` confirms the action fails when merge commit count meets the max
- Verify `TestResolveConflictsAction_CleanMerge` and `TestResolveConflictsAction_ConflictsStartWorker` work without step data round tracking