### PR TITLE
feat(daemon): derive address-review round counter from PR marker comments

### DIFF
--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -768,16 +768,34 @@ func (a *addressReviewAction) Execute(ctx context.Context, ac *workflow.ActionCo
 		return workflow.ActionResult{Error: fmt.Errorf("work item not found: %s", ac.WorkItemID)}
 	}
 
-	// Check max rounds
+	sess, err := d.getSessionOrError(item.SessionID)
+	if err != nil {
+		return workflow.ActionResult{Error: err}
+	}
+
+	// Derive round count from observable PR state rather than local StepData,
+	// so the counter is correct even after daemon restarts or step re-runs.
+	countCtx, countCancel := context.WithTimeout(ctx, timeoutStandardOp)
+	defer countCancel()
 	maxRounds := ac.Params.Int("max_review_rounds", 3)
-	rounds := getReviewRounds(item.StepData)
+	rounds := d.countAddressReviewRoundsFromPR(countCtx, sess.RepoPath, item.Branch)
 	if rounds >= maxRounds {
 		return workflow.ActionResult{Error: fmt.Errorf("max review rounds exceeded (%d/%d)", rounds, maxRounds)}
 	}
 
-	sess, err := d.getSessionOrError(item.SessionID)
-	if err != nil {
-		return workflow.ActionResult{Error: err}
+	// Post a marker comment on the PR to record this round. The comment is
+	// intentionally not deduplicated: each invocation creates a new comment so
+	// that countAddressReviewRoundsFromPR can derive the count on future runs.
+	markerCtx, markerCancel := context.WithTimeout(ctx, timeoutStandardOp)
+	defer markerCancel()
+	prNum, prErr := d.gitService.GetPRNumber(markerCtx, sess.RepoPath, item.Branch)
+	if prErr == nil {
+		body := fmt.Sprintf("Starting review address round %d.\n%s", rounds+1, AddressReviewRoundMarker)
+		if err := d.gitService.CommentOnIssue(markerCtx, sess.RepoPath, prNum, body); err != nil {
+			d.logger.Warn("failed to post address-review round marker", "error", err, "round", rounds+1)
+		}
+	} else {
+		d.logger.Warn("failed to get PR number for address-review round marker", "error", prErr)
 	}
 
 	// Fetch review comments
@@ -791,12 +809,6 @@ func (a *addressReviewAction) Execute(ctx context.Context, ac *workflow.ActionCo
 
 	// Filter out daemon transcript comments
 	reviewComments := worker.FilterTranscriptComments(comments)
-
-	// Increment rounds
-	d.state.UpdateWorkItem(item.ID, func(it *daemonstate.WorkItem) {
-		it.StepData["review_rounds"] = rounds + 1
-		it.UpdatedAt = time.Now()
-	})
 
 	// Resume session
 	if err := d.startAddressReview(ctx, item, sess, rounds+1, reviewComments); err != nil {

--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -4968,8 +4968,23 @@ func TestAddressReviewAction_Execute_WorkItemNotFound(t *testing.T) {
 
 func TestAddressReviewAction_Execute_MaxRoundsExceeded(t *testing.T) {
 	cfg := testConfig()
-	d := testDaemon(cfg)
+	mockExec := exec.NewMockExecutor(nil)
 
+	// Mock PR number lookup for countAddressReviewRoundsFromPR
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view", "feature-sess-1", "--json", "number"},
+		exec.MockResponse{Stdout: []byte(`{"number": 42}`)})
+
+	// Mock comments listing: return 3 comments that each contain the round marker
+	roundMarkerComment := `{"id": %d, "body": "Starting review address round %d.\n` + AddressReviewRoundMarker + `"}`
+	commentsJSON := fmt.Sprintf("[%s,%s,%s]",
+		fmt.Sprintf(roundMarkerComment, 1, 1),
+		fmt.Sprintf(roundMarkerComment, 2, 2),
+		fmt.Sprintf(roundMarkerComment, 3, 3),
+	)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"},
+		exec.MockResponse{Stdout: []byte(commentsJSON)})
+
+	d := testDaemonWithExec(cfg, mockExec)
 	sess := testSession("sess-1")
 	cfg.AddSession(*sess)
 	d.state.AddWorkItem(&daemonstate.WorkItem{
@@ -4977,7 +4992,7 @@ func TestAddressReviewAction_Execute_MaxRoundsExceeded(t *testing.T) {
 		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
 		SessionID: "sess-1",
 		Branch:    "feature-sess-1",
-		StepData:  map[string]any{"review_rounds": 3},
+		StepData:  map[string]any{},
 	})
 
 	action := &addressReviewAction{daemon: d}
@@ -4994,35 +5009,6 @@ func TestAddressReviewAction_Execute_MaxRoundsExceeded(t *testing.T) {
 	}
 	if result.Error == nil || !strings.Contains(result.Error.Error(), "max review rounds exceeded") {
 		t.Errorf("expected 'max review rounds exceeded' error, got: %v", result.Error)
-	}
-}
-
-func TestAddressReviewAction_Execute_MaxRoundsFloat64(t *testing.T) {
-	// JSON deserialization produces float64 for numbers
-	cfg := testConfig()
-	d := testDaemon(cfg)
-
-	sess := testSession("sess-1")
-	cfg.AddSession(*sess)
-	d.state.AddWorkItem(&daemonstate.WorkItem{
-		ID:        "item-1",
-		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
-		SessionID: "sess-1",
-		Branch:    "feature-sess-1",
-		StepData:  map[string]any{"review_rounds": float64(3)},
-	})
-
-	action := &addressReviewAction{daemon: d}
-	params := workflow.NewParamHelper(map[string]any{"max_review_rounds": 3})
-	ac := &workflow.ActionContext{
-		WorkItemID: "item-1",
-		Params:     params,
-	}
-
-	result := action.Execute(context.Background(), ac)
-
-	if result.Success {
-		t.Error("expected error when max rounds exceeded (float64)")
 	}
 }
 
@@ -5054,25 +5040,82 @@ func TestAddressReviewAction_Execute_NoSession(t *testing.T) {
 	}
 }
 
-func TestGetReviewRounds(t *testing.T) {
-	tests := []struct {
-		name     string
-		stepData map[string]any
-		want     int
-	}{
-		{"missing", map[string]any{}, 0},
-		{"int zero", map[string]any{"review_rounds": 0}, 0},
-		{"int one", map[string]any{"review_rounds": 1}, 1},
-		{"int three", map[string]any{"review_rounds": 3}, 3},
-		{"float64 zero", map[string]any{"review_rounds": float64(0)}, 0},
-		{"float64 two", map[string]any{"review_rounds": float64(2)}, 2},
-		{"wrong type", map[string]any{"review_rounds": "oops"}, 0},
+func TestCountAddressReviewRoundsFromPR(t *testing.T) {
+	const branch = "feature-1"
+	const commentsEndpoint = "repos/:owner/:repo/issues/42/comments"
+
+	marker := AddressReviewRoundMarker
+	markerComment := func(id int) string {
+		return fmt.Sprintf(`{"id":%d,"body":"Starting review address round %d.\n%s"}`, id, id, marker)
 	}
+	otherComment := func(id int) string {
+		return fmt.Sprintf(`{"id":%d,"body":"just a regular comment"}`, id)
+	}
+
+	tests := []struct {
+		name         string
+		prViewOutput []byte
+		prViewErr    error
+		commentsJSON []byte
+		commentsErr  error
+		want         int
+	}{
+		{
+			name:      "PR number lookup fails",
+			prViewErr: fmt.Errorf("no PR"),
+			want:      0,
+		},
+		{
+			name:         "comments listing fails",
+			prViewOutput: []byte(`{"number":42}`),
+			commentsErr:  fmt.Errorf("api error"),
+			want:         0,
+		},
+		{
+			name:         "no marker comments",
+			prViewOutput: []byte(`{"number":42}`),
+			commentsJSON: []byte(fmt.Sprintf("[%s,%s]", otherComment(1), otherComment(2))),
+			want:         0,
+		},
+		{
+			name:         "one round marker",
+			prViewOutput: []byte(`{"number":42}`),
+			commentsJSON: []byte(fmt.Sprintf("[%s]", markerComment(1))),
+			want:         1,
+		},
+		{
+			name:         "three round markers",
+			prViewOutput: []byte(`{"number":42}`),
+			commentsJSON: []byte(fmt.Sprintf("[%s,%s,%s]", markerComment(1), markerComment(2), markerComment(3))),
+			want:         3,
+		},
+		{
+			name:         "two markers among other comments",
+			prViewOutput: []byte(`{"number":42}`),
+			commentsJSON: []byte(fmt.Sprintf("[%s,%s,%s,%s]", otherComment(1), markerComment(2), otherComment(3), markerComment(4))),
+			want:         2,
+		},
+	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getReviewRounds(tc.stepData)
+			cfg := testConfig()
+			mockExec := exec.NewMockExecutor(nil)
+
+			mockExec.AddExactMatch("gh",
+				[]string{"pr", "view", branch, "--json", "number"},
+				exec.MockResponse{Stdout: tc.prViewOutput, Err: tc.prViewErr})
+			if tc.prViewErr == nil {
+				mockExec.AddExactMatch("gh",
+					[]string{"api", commentsEndpoint},
+					exec.MockResponse{Stdout: tc.commentsJSON, Err: tc.commentsErr})
+			}
+
+			d := testDaemonWithExec(cfg, mockExec)
+
+			got := d.countAddressReviewRoundsFromPR(context.Background(), "/test/repo", branch)
 			if got != tc.want {
-				t.Errorf("getReviewRounds(%v) = %d, want %d", tc.stepData, got, tc.want)
+				t.Errorf("countAddressReviewRoundsFromPR() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/internal/daemon/coding.go
+++ b/internal/daemon/coding.go
@@ -987,20 +987,35 @@ INSTRUCTIONS:
 DO NOT push or create PRs — the system handles this.`, round)
 }
 
-// getReviewRounds extracts the review round counter from step data.
-func getReviewRounds(stepData map[string]any) int {
-	v, ok := stepData["review_rounds"]
-	if !ok {
+// AddressReviewRoundMarker is the HTML comment marker embedded in PR comments
+// to track each address-review round. It is invisible when rendered by GitHub's
+// Markdown parser. The round count is derived by counting PR comments that
+// contain this marker — each invocation posts a new comment rather than updating
+// an existing one, so the count equals the number of rounds started.
+const AddressReviewRoundMarker = "<!-- erg:address_review_round -->"
+
+// countAddressReviewRoundsFromPR counts how many address-review rounds have been
+// started by counting PR comments that contain AddressReviewRoundMarker.
+// Returns 0 if the PR number cannot be resolved or comments cannot be listed,
+// so that a transient failure does not block progress.
+func (d *Daemon) countAddressReviewRoundsFromPR(ctx context.Context, repoPath, branch string) int {
+	prNum, err := d.gitService.GetPRNumber(ctx, repoPath, branch)
+	if err != nil {
+		d.logger.Debug("countAddressReviewRoundsFromPR: could not get PR number, returning 0", "error", err)
 		return 0
 	}
-	switch n := v.(type) {
-	case int:
-		return n
-	case float64:
-		return int(n)
-	default:
+	comments, err := d.gitService.ListIssueComments(ctx, repoPath, prNum)
+	if err != nil {
+		d.logger.Debug("countAddressReviewRoundsFromPR: could not list comments, returning 0", "error", err)
 		return 0
 	}
+	count := 0
+	for _, c := range comments {
+		if strings.Contains(c.Body, AddressReviewRoundMarker) {
+			count++
+		}
+	}
+	return count
 }
 
 // writePRDescription generates a rich PR description from the branch diff and updates the PR body.


### PR DESCRIPTION
## Summary
Replace the local `StepData`-based review round counter with a durable, observable counter derived from PR comments. This ensures the round count is correct even after daemon restarts or step re-runs.

## Changes
- Add `AddressReviewRoundMarker` constant (HTML comment invisible in rendered Markdown) to tag each address-review round
- Add `countAddressReviewRoundsFromPR` method that counts PR comments containing the marker instead of reading from `StepData`
- Post a new marker comment on the PR at the start of each address-review round
- Remove `getReviewRounds` helper and the `StepData["review_rounds"]` increment logic
- Update tests: replace `TestGetReviewRounds` with `TestCountAddressReviewRoundsFromPR` covering PR lookup failures, comment listing failures, mixed comments, and multiple markers
- Remove `TestAddressReviewAction_Execute_MaxRoundsFloat64` (no longer relevant since rounds aren't stored as step data)
- Update `TestAddressReviewAction_Execute_MaxRoundsExceeded` to use mock executor with PR/comment responses

## Test plan
- Run `go test -p=1 -count=1 ./internal/daemon/...` to verify all updated and new tests pass
- Verify `TestCountAddressReviewRoundsFromPR` covers: PR lookup failure, comments listing failure, no markers, one marker, three markers, and markers mixed with regular comments
- Verify `TestAddressReviewAction_Execute_MaxRoundsExceeded` correctly simulates the round limit being hit via PR comment counting