### PR TITLE
feat(daemon): add wait-state guidance and prevent daemon self-approval

### DIFF
--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -5,12 +5,22 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/zhubert/erg/internal/git"
 	"github.com/zhubert/erg/internal/issues"
 	"github.com/zhubert/erg/internal/workflow"
 )
+
+// isErgSystemComment reports whether a comment body was posted by the erg daemon
+// itself (e.g. guidance, idempotency-marked actions). Such comments must be
+// excluded from human-reply checks so they never accidentally trigger approvals.
+func isErgSystemComment(body string) bool {
+	// Provider-marker format used for Asana/Linear comments: [erg:step=…]
+	// HTML-comment format used for GitHub: <!-- erg:step=… -->
+	return strings.Contains(body, "[erg:step=") || strings.Contains(body, "<!-- erg:step=")
+}
 
 // eventChecker implements workflow.EventChecker for the daemon.
 type eventChecker struct {
@@ -436,6 +446,10 @@ func (c *eventChecker) checkGateApproved(ctx context.Context, params *workflow.P
 		}
 
 		for _, comment := range comments {
+			// Skip comments posted by the erg daemon itself (e.g. guidance, markers).
+			if isErgSystemComment(comment.Body) {
+				continue
+			}
 			// Only consider comments posted after the gate step was entered.
 			if !item.StepEnteredAt.IsZero() && !comment.CreatedAt.After(item.StepEnteredAt) {
 				continue
@@ -566,6 +580,10 @@ func (c *eventChecker) checkPlanUserReplied(ctx context.Context, params *workflo
 	}
 
 	for _, comment := range comments {
+		// Skip comments posted by the erg daemon itself (e.g. guidance, markers).
+		if isErgSystemComment(comment.Body) {
+			continue
+		}
 		// Only consider comments posted after the step was entered.
 		if !item.StepEnteredAt.IsZero() && !comment.CreatedAt.After(item.StepEnteredAt) {
 			continue

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -3341,3 +3341,127 @@ func TestCheckEvent_LinearInState_Dispatches(t *testing.T) {
 		t.Error("expected CheckEvent to dispatch to linear.in_state and fire")
 	}
 }
+
+// --- isErgSystemComment / guidance self-trigger prevention ---
+
+func TestIsErgSystemComment_AsanaMarker(t *testing.T) {
+	// Asana/Linear provider marker format
+	body := "The plan above is ready for your review.\n[erg:step=await_plan_feedback]"
+	if !isErgSystemComment(body) {
+		t.Error("expected Asana marker to be detected as system comment")
+	}
+}
+
+func TestIsErgSystemComment_GitHubMarker(t *testing.T) {
+	// GitHub HTML comment marker format
+	body := "Please review and approve the PR.\n<!-- erg:step=await_review -->"
+	if !isErgSystemComment(body) {
+		t.Error("expected GitHub marker to be detected as system comment")
+	}
+}
+
+func TestIsErgSystemComment_HumanComment(t *testing.T) {
+	humanComments := []string{
+		"LGTM",
+		"Looks good to me, approved",
+		"proceed",
+		"please make these changes",
+		"approved",
+	}
+	for _, body := range humanComments {
+		if isErgSystemComment(body) {
+			t.Errorf("human comment %q incorrectly flagged as system comment", body)
+		}
+	}
+}
+
+// TestCheckPlanUserReplied_GuidanceCommentNotSelfApproved is a regression test:
+// the guidance comment posted by the daemon must not trigger plan.user_replied.
+func TestCheckPlanUserReplied_GuidanceCommentNotSelfApproved(t *testing.T) {
+	cfg := testConfig()
+	now := time.Now()
+
+	// Simulate the guidance comment that postWaitGuidance would post.
+	// It contains words like "approved" and "proceed" which match typical patterns.
+	guidanceBody := `The plan above is ready for your review. Reply with your feedback to request changes, or reply with an approval (e.g. "LGTM", "looks good", "approved") to proceed.
+[erg:step=await_plan_feedback]`
+
+	provider := &mockGateProvider{
+		src: issues.SourceAsana,
+		comments: []issues.IssueComment{
+			{Author: "erg-bot", Body: guidanceBody, CreatedAt: now.Add(time.Minute)},
+		},
+	}
+	d := testDaemonWithGateProvider(cfg, provider)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "asana", ID: "task-gid-999"},
+		SessionID:   "sess-1",
+		CurrentStep: "await_plan_feedback",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{
+		"approval_pattern": `(?i)(LGTM|looks good|approved?|proceed|go ahead|ship it)`,
+	})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+	view.StepEnteredAt = now
+
+	fired, _, err := checker.checkPlanUserReplied(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fired {
+		t.Error("guidance comment must not trigger plan.user_replied (would auto-approve plan)")
+	}
+}
+
+// TestCheckGateApproved_GuidanceCommentNotSelfApproved is a regression test:
+// the guidance comment posted by the daemon must not trigger gate.approved.
+func TestCheckGateApproved_GuidanceCommentNotSelfApproved(t *testing.T) {
+	cfg := testConfig()
+	now := time.Now()
+
+	// A guidance comment for comment_match gate includes the pattern string.
+	guidanceBody := "Reply to this issue with a comment matching: `(?i)LGTM`\n[erg:step=await_gate]"
+
+	provider := &mockGateProvider{
+		src: issues.SourceAsana,
+		comments: []issues.IssueComment{
+			{Author: "erg-bot", Body: guidanceBody, CreatedAt: now.Add(time.Minute)},
+		},
+	}
+	d := testDaemonWithGateProvider(cfg, provider)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "asana", ID: "task-gid-888"},
+		SessionID:   "sess-1",
+		CurrentStep: "await_gate",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{
+		"trigger":         "comment_match",
+		"comment_pattern": "(?i)LGTM",
+	})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+	view.StepEnteredAt = now
+
+	fired, _, err := checker.checkGateApproved(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fired {
+		t.Error("guidance comment must not trigger gate.approved (would auto-approve gate)")
+	}
+}

--- a/internal/daemon/processing.go
+++ b/internal/daemon/processing.go
@@ -359,14 +359,26 @@ func (d *Daemon) executeSyncChain(ctx context.Context, itemID string, engine *wo
 			})
 		}
 
+		// Post guidance BEFORE AdvanceWorkItem so the comment's provider-side
+		// timestamp precedes StepEnteredAt. This prevents the guidance comment
+		// from being treated as a human reply by plan.user_replied / gate.approved
+		// event checkers, which only consider comments posted after StepEnteredAt.
+		if result.NewPhase != "async_pending" {
+			nextState := engine.GetState(result.NewStep)
+			if nextState != nil && nextState.Type == workflow.StateTypeWait {
+				if fresh, ok := d.state.GetWorkItem(itemID); ok {
+					d.postWaitGuidance(ctx, fresh, result.NewStep, nextState)
+				}
+			}
+		}
+
 		d.state.AdvanceWorkItem(item.ID, result.NewStep, result.NewPhase)
 
 		// Stop if we hit an async pending state or a wait state
 		if result.NewPhase == "async_pending" {
 			return
 		}
-		nextState := engine.GetState(result.NewStep)
-		if nextState != nil && nextState.Type == workflow.StateTypeWait {
+		if nextState := engine.GetState(result.NewStep); nextState != nil && nextState.Type == workflow.StateTypeWait {
 			return
 		}
 	}

--- a/internal/daemon/wait_guidance.go
+++ b/internal/daemon/wait_guidance.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+
+	"github.com/zhubert/erg/internal/daemonstate"
+	"github.com/zhubert/erg/internal/issues"
+	"github.com/zhubert/erg/internal/workflow"
+)
+
+// postWaitGuidance posts a guidance comment on the issue tracker when the workflow
+// enters a wait state that requires human action. The comment is idempotent: if a
+// comment with the same step marker already exists it is updated in place.
+//
+// This is best-effort: failures are logged but do not affect the workflow.
+func (d *Daemon) postWaitGuidance(ctx context.Context, item daemonstate.WorkItem, stepName string, state *workflow.State) {
+	msg := workflow.WaitStateGuidance(state, item.PRURL)
+	if msg == "" {
+		return
+	}
+
+	log := d.logger.With("workItem", item.ID, "step", stepName, "event", state.Event)
+
+	source := issues.Source(item.IssueRef.Source)
+	var postErr error
+
+	switch source {
+	case issues.SourceGitHub:
+		postErr = d.postGuidanceGitHub(ctx, item, stepName, msg)
+	case issues.SourceAsana:
+		params := workflow.NewParamHelper(map[string]any{"body": msg})
+		postErr = d.commentViaProvider(ctx, item, params, issues.SourceAsana, stepName)
+	case issues.SourceLinear:
+		params := workflow.NewParamHelper(map[string]any{"body": msg})
+		postErr = d.commentViaProvider(ctx, item, params, issues.SourceLinear, stepName)
+	default:
+		log.Debug("guidance posting not supported for source", "source", source)
+		return
+	}
+
+	if postErr != nil {
+		log.Warn("failed to post wait state guidance (non-fatal)", "error", postErr)
+	} else {
+		log.Info("posted wait state guidance")
+	}
+}
+
+// postGuidanceGitHub posts a guidance comment on a GitHub issue.
+// It tries the provider registry first (if a GitHub provider is registered),
+// then falls back to the git service. The comment is idempotent via step marker.
+func (d *Daemon) postGuidanceGitHub(ctx context.Context, item daemonstate.WorkItem, stepName, msg string) error {
+	// Try the provider registry first.
+	if d.issueRegistry != nil {
+		if p := d.issueRegistry.GetProvider(issues.SourceGitHub); p != nil {
+			if pa, ok := p.(issues.ProviderActions); ok {
+				repoPath := d.resolveRepoPath(ctx, item)
+				marker := ergGitHubMarker(stepName)
+				markedBody := msg + "\n" + marker
+
+				commentCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
+				defer cancel()
+
+				// Idempotent upsert if provider supports it.
+				if gc, ok := p.(issues.ProviderGateChecker); ok {
+					if cu, ok := p.(issues.ProviderCommentUpdater); ok {
+						existing, listErr := gc.GetIssueComments(commentCtx, repoPath, item.IssueRef.ID)
+						if listErr == nil {
+							for _, c := range existing {
+								if strings.Contains(c.Body, marker) {
+									return cu.UpdateComment(commentCtx, repoPath, item.IssueRef.ID, c.ID, markedBody)
+								}
+							}
+						}
+					}
+				}
+				return pa.Comment(commentCtx, repoPath, item.IssueRef.ID, markedBody)
+			}
+		}
+	}
+
+	// Fall back to git service for GitHub (handles idempotency via step marker).
+	params := workflow.NewParamHelper(map[string]any{"body": msg})
+	return d.commentOnIssue(ctx, item, params, stepName)
+}

--- a/internal/daemon/wait_guidance_test.go
+++ b/internal/daemon/wait_guidance_test.go
@@ -1,0 +1,301 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/zhubert/erg/internal/config"
+	"github.com/zhubert/erg/internal/daemonstate"
+	"github.com/zhubert/erg/internal/issues"
+	"github.com/zhubert/erg/internal/workflow"
+)
+
+// guidanceTestProvider is a minimal provider that captures Comment calls.
+type guidanceTestProvider struct {
+	src      issues.Source
+	comments []string
+}
+
+func (p *guidanceTestProvider) Name() string                             { return string(p.src) }
+func (p *guidanceTestProvider) Source() issues.Source                    { return p.src }
+func (p *guidanceTestProvider) IsConfigured(_ string) bool               { return true }
+func (p *guidanceTestProvider) GenerateBranchName(_ issues.Issue) string { return "" }
+func (p *guidanceTestProvider) GetPRLinkText(_ issues.Issue) string      { return "" }
+func (p *guidanceTestProvider) FetchIssues(_ context.Context, _ string, _ issues.FilterConfig) ([]issues.Issue, error) {
+	return nil, nil
+}
+func (p *guidanceTestProvider) RemoveLabel(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
+func (p *guidanceTestProvider) Comment(_ context.Context, _, _, body string) error {
+	p.comments = append(p.comments, body)
+	return nil
+}
+
+func makeGuidanceItem(source, issueID string) daemonstate.WorkItem {
+	return daemonstate.WorkItem{
+		ID: "wi-guidance-test",
+		IssueRef: config.IssueRef{
+			Source: source,
+			ID:     issueID,
+			Title:  "Test issue",
+		},
+	}
+}
+
+func TestPostWaitGuidance_SkipsAutomatedEvents(t *testing.T) {
+	automated := []string{"ci.complete", "ci.wait_for_checks", "pr.mergeable"}
+	for _, event := range automated {
+		t.Run(event, func(t *testing.T) {
+			cfg := testConfig()
+			d := testDaemon(cfg)
+			prov := &guidanceTestProvider{src: issues.SourceGitHub}
+			d.issueRegistry = issues.NewProviderRegistry(prov)
+
+			item := makeGuidanceItem("github", "42")
+			state := &workflow.State{
+				Type:  workflow.StateTypeWait,
+				Event: event,
+			}
+			d.postWaitGuidance(context.Background(), item, "wait_step", state)
+
+			if len(prov.comments) != 0 {
+				t.Errorf("expected no comment for automated event %q, got %d", event, len(prov.comments))
+			}
+		})
+	}
+}
+
+func TestPostWaitGuidance_PostsForGateApproved(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	prov := &guidanceTestProvider{src: issues.SourceGitHub}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	// Add a session so commentOnIssue can resolve the repo path
+	sess := &config.Session{
+		ID:       "sess-gate",
+		RepoPath: "/test/repo",
+		Branch:   "feat-1",
+		IssueRef: &config.IssueRef{Source: "github", ID: "42"},
+	}
+	cfg.AddSession(*sess)
+
+	item := makeGuidanceItem("github", "42")
+	item.SessionID = "sess-gate"
+
+	state := &workflow.State{
+		Type:  workflow.StateTypeWait,
+		Event: "gate.approved",
+		Params: map[string]any{
+			"trigger": "label_added",
+			"label":   "approved",
+		},
+	}
+	d.postWaitGuidance(context.Background(), item, "await_gate", state)
+
+	if len(prov.comments) == 0 {
+		t.Fatal("expected a comment to be posted")
+	}
+	body := prov.comments[0]
+	if !strings.Contains(body, "approved") {
+		t.Errorf("expected label name in comment, got: %q", body)
+	}
+}
+
+func TestPostWaitGuidance_PostsForPlanUserReplied(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	prov := &guidanceTestProvider{src: issues.SourceGitHub}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	sess := &config.Session{
+		ID:       "sess-plan",
+		RepoPath: "/test/repo",
+		Branch:   "feat-plan",
+		IssueRef: &config.IssueRef{Source: "github", ID: "10"},
+	}
+	cfg.AddSession(*sess)
+
+	item := makeGuidanceItem("github", "10")
+	item.SessionID = "sess-plan"
+
+	state := &workflow.State{
+		Type:  workflow.StateTypeWait,
+		Event: "plan.user_replied",
+		Params: map[string]any{
+			"approval_pattern": `(?i)(LGTM|looks good|approved?)`,
+		},
+	}
+	d.postWaitGuidance(context.Background(), item, "await_plan_feedback", state)
+
+	if len(prov.comments) == 0 {
+		t.Fatal("expected a comment to be posted")
+	}
+	body := prov.comments[0]
+	if !strings.Contains(body, "plan") {
+		t.Errorf("expected 'plan' in comment body, got: %q", body)
+	}
+}
+
+func TestPostWaitGuidance_PRReviewed_IncludesPRURL(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	prov := &guidanceTestProvider{src: issues.SourceGitHub}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	sess := &config.Session{
+		ID:       "sess-pr",
+		RepoPath: "/test/repo",
+		Branch:   "feat-pr",
+		IssueRef: &config.IssueRef{Source: "github", ID: "7"},
+	}
+	cfg.AddSession(*sess)
+
+	prURL := "https://github.com/owner/repo/pull/99"
+	item := makeGuidanceItem("github", "7")
+	item.SessionID = "sess-pr"
+	item.PRURL = prURL
+
+	state := &workflow.State{
+		Type:  workflow.StateTypeWait,
+		Event: "pr.reviewed",
+	}
+	d.postWaitGuidance(context.Background(), item, "await_review", state)
+
+	if len(prov.comments) == 0 {
+		t.Fatal("expected a comment to be posted")
+	}
+	body := prov.comments[0]
+	if !strings.Contains(body, prURL) {
+		t.Errorf("expected PR URL in comment, got: %q", body)
+	}
+}
+
+func TestPostWaitGuidance_ExplicitSuppression(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	prov := &guidanceTestProvider{src: issues.SourceGitHub}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	sess := &config.Session{
+		ID:       "sess-suppress",
+		RepoPath: "/test/repo",
+		Branch:   "feat-suppress",
+		IssueRef: &config.IssueRef{Source: "github", ID: "5"},
+	}
+	cfg.AddSession(*sess)
+
+	item := makeGuidanceItem("github", "5")
+	item.SessionID = "sess-suppress"
+
+	empty := ""
+	state := &workflow.State{
+		Type:     workflow.StateTypeWait,
+		Event:    "gate.approved",
+		Guidance: &empty, // explicit suppression
+	}
+	d.postWaitGuidance(context.Background(), item, "await_gate", state)
+
+	if len(prov.comments) != 0 {
+		t.Errorf("expected no comment when guidance is suppressed, got %d", len(prov.comments))
+	}
+}
+
+func TestPostWaitGuidance_CustomGuidanceMessage(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	prov := &guidanceTestProvider{src: issues.SourceGitHub}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	sess := &config.Session{
+		ID:       "sess-custom",
+		RepoPath: "/test/repo",
+		Branch:   "feat-custom",
+		IssueRef: &config.IssueRef{Source: "github", ID: "3"},
+	}
+	cfg.AddSession(*sess)
+
+	item := makeGuidanceItem("github", "3")
+	item.SessionID = "sess-custom"
+
+	custom := "Do the special approval dance."
+	state := &workflow.State{
+		Type:     workflow.StateTypeWait,
+		Event:    "gate.approved",
+		Guidance: &custom,
+	}
+	d.postWaitGuidance(context.Background(), item, "await_gate", state)
+
+	if len(prov.comments) == 0 {
+		t.Fatal("expected a comment to be posted")
+	}
+	body := prov.comments[0]
+	if !strings.Contains(body, custom) {
+		t.Errorf("expected custom guidance in comment, got: %q", body)
+	}
+}
+
+func TestPostWaitGuidance_AsanaProvider(t *testing.T) {
+	cfg := testConfig()
+	cfg.AddRepo("/test/repo")
+	d := testDaemon(cfg)
+	d.repoFilter = "/test/repo"
+	prov := &guidanceTestProvider{src: issues.SourceAsana}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	item := makeGuidanceItem("asana", "task-123")
+	state := &workflow.State{
+		Type:   workflow.StateTypeWait,
+		Event:  "asana.in_section",
+		Params: map[string]any{"section": "Doing"},
+	}
+	d.postWaitGuidance(context.Background(), item, "await_doing", state)
+
+	if len(prov.comments) == 0 {
+		t.Fatal("expected a comment to be posted via Asana provider")
+	}
+	body := prov.comments[0]
+	if !strings.Contains(body, "Doing") {
+		t.Errorf("expected section name in comment, got: %q", body)
+	}
+}
+
+func TestPostWaitGuidance_LinearProvider(t *testing.T) {
+	cfg := testConfig()
+	cfg.AddRepo("/test/repo")
+	d := testDaemon(cfg)
+	d.repoFilter = "/test/repo"
+	prov := &guidanceTestProvider{src: issues.SourceLinear}
+	d.issueRegistry = issues.NewProviderRegistry(prov)
+
+	item := makeGuidanceItem("linear", "issue-abc")
+	state := &workflow.State{
+		Type:   workflow.StateTypeWait,
+		Event:  "linear.in_state",
+		Params: map[string]any{"state": "In Progress"},
+	}
+	d.postWaitGuidance(context.Background(), item, "await_doing", state)
+
+	if len(prov.comments) == 0 {
+		t.Fatal("expected a comment to be posted via Linear provider")
+	}
+	body := prov.comments[0]
+	if !strings.Contains(body, "In Progress") {
+		t.Errorf("expected state name in comment, got: %q", body)
+	}
+}
+
+func TestPostWaitGuidance_UnknownSource_NoComment(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	item := makeGuidanceItem("jira", "PROJ-42")
+	state := &workflow.State{
+		Type:  workflow.StateTypeWait,
+		Event: "gate.approved",
+	}
+	// Should not panic — just log and return
+	d.postWaitGuidance(context.Background(), item, "await_gate", state)
+}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -57,6 +57,10 @@ type State struct {
 	Data        map[string]any `yaml:"data,omitempty"`
 	Before      []HookConfig   `yaml:"before,omitempty"`
 	After       []HookConfig   `yaml:"after,omitempty"`
+	// Guidance is an optional message posted to the issue tracker when this wait
+	// state is entered, telling the human what action is required to proceed.
+	// nil = auto-generate from event type; "" = suppress guidance; non-empty = use as-is.
+	Guidance *string `yaml:"guidance,omitempty"`
 }
 
 // ChoiceRule defines a conditional branch in a choice state.

--- a/internal/workflow/guidance.go
+++ b/internal/workflow/guidance.go
@@ -1,0 +1,120 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// WaitStateGuidance generates a human-readable guidance message for a wait state
+// that requires human action. Returns empty string for automated wait states
+// (ci.complete, ci.wait_for_checks, pr.mergeable) or when guidance is suppressed.
+//
+// prURL is included in the message for pr.reviewed events so the human can
+// navigate directly to the pull request.
+//
+// If state.Guidance is non-nil, it is used directly (empty string suppresses guidance).
+func WaitStateGuidance(state *State, prURL string) string {
+	if state.Guidance != nil {
+		return *state.Guidance
+	}
+
+	params := NewParamHelper(state.Params)
+
+	switch state.Event {
+	case "gate.approved":
+		return gateApprovedGuidance(params)
+	case "plan.user_replied":
+		return planUserRepliedGuidance(params)
+	case "pr.reviewed":
+		return prReviewedGuidance(prURL)
+	case "asana.in_section":
+		section := params.String("section", "")
+		if section != "" {
+			return fmt.Sprintf("Move this task to the **%s** section in Asana to proceed.", section)
+		}
+		return "Move this task to the required section in Asana to proceed."
+	case "linear.in_state":
+		ls := params.String("state", "")
+		if ls != "" {
+			return fmt.Sprintf("Move this issue to the **%s** state in Linear to proceed.", ls)
+		}
+		return "Move this issue to the required state in Linear to proceed."
+	default:
+		// ci.complete, ci.wait_for_checks, pr.mergeable — automated, no human action needed
+		return ""
+	}
+}
+
+func gateApprovedGuidance(params *ParamHelper) string {
+	trigger := params.String("trigger", "label_added")
+	switch trigger {
+	case "comment_match":
+		pattern := params.String("pattern", "")
+		if pattern != "" {
+			return fmt.Sprintf("Reply to this issue with a comment matching: `%s`", pattern)
+		}
+		return "Reply to this issue with an approval comment to proceed."
+	default: // label_added
+		label := params.String("label", "approved")
+		return fmt.Sprintf("Add the label **`%s`** to this issue to proceed.", label)
+	}
+}
+
+func planUserRepliedGuidance(params *ParamHelper) string {
+	approvalPattern := params.String("approval_pattern", "")
+	if approvalPattern != "" {
+		examples := patternExamples(approvalPattern)
+		if len(examples) > 0 {
+			return fmt.Sprintf(
+				"The plan above is ready for your review. Reply with your feedback to request changes, "+
+					"or reply with an approval (e.g. %s) to proceed.",
+				strings.Join(examples, ", "),
+			)
+		}
+	}
+	return "The plan above is ready for your review. Reply with your feedback or approval to proceed."
+}
+
+func prReviewedGuidance(prURL string) string {
+	if prURL != "" {
+		return fmt.Sprintf("A pull request is ready for your review: %s\n\nPlease review and approve it to proceed.", prURL)
+	}
+	return "A pull request is ready for your review. Please review and approve it to proceed."
+}
+
+// patternExamples extracts simple literal alternatives from a regex pattern like
+// "(?i)(LGTM|looks good|approved?|proceed)" and returns up to 3 as quoted strings.
+// Returns nil if the pattern is too complex to parse usefully.
+func patternExamples(pattern string) []string {
+	s := pattern
+	s = strings.TrimPrefix(s, "(?i)")
+	s = strings.Trim(s, "^$")
+	s = strings.Trim(s, "()")
+
+	parts := strings.Split(s, "|")
+	if len(parts) == 0 {
+		return nil
+	}
+
+	var examples []string
+	for _, p := range parts {
+		clean := strings.TrimRight(p, "?")
+		if !hasComplexRegex(clean) {
+			examples = append(examples, fmt.Sprintf("%q", clean))
+		}
+		if len(examples) == 3 {
+			break
+		}
+	}
+	return examples
+}
+
+func hasComplexRegex(s string) bool {
+	for _, c := range s {
+		switch c {
+		case '.', '*', '+', '[', ']', '{', '}', '\\', '^', '$', '(', ')':
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflow/guidance_test.go
+++ b/internal/workflow/guidance_test.go
@@ -1,0 +1,202 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestWaitStateGuidance_ExplicitOverride(t *testing.T) {
+	custom := "Please do the thing."
+	state := &State{Event: "gate.approved", Guidance: ptr(custom)}
+	got := WaitStateGuidance(state, "")
+	if got != custom {
+		t.Errorf("expected %q, got %q", custom, got)
+	}
+}
+
+func TestWaitStateGuidance_ExplicitSuppression(t *testing.T) {
+	empty := ""
+	state := &State{Event: "gate.approved", Guidance: ptr(empty)}
+	got := WaitStateGuidance(state, "")
+	if got != "" {
+		t.Errorf("expected empty string for suppressed guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_GateApproved_LabelAdded(t *testing.T) {
+	state := &State{
+		Event: "gate.approved",
+		Params: map[string]any{
+			"trigger": "label_added",
+			"label":   "approved",
+		},
+	}
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "approved") {
+		t.Errorf("expected label name in guidance, got %q", got)
+	}
+	if !strings.Contains(got, "label") {
+		t.Errorf("expected 'label' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_GateApproved_DefaultLabel(t *testing.T) {
+	state := &State{Event: "gate.approved"} // no params
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "approved") {
+		t.Errorf("expected default label 'approved' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_GateApproved_CommentMatch(t *testing.T) {
+	state := &State{
+		Event: "gate.approved",
+		Params: map[string]any{
+			"trigger": "comment_match",
+			"pattern": "(?i)LGTM",
+		},
+	}
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "(?i)LGTM") {
+		t.Errorf("expected pattern in guidance, got %q", got)
+	}
+	if !strings.Contains(got, "comment") {
+		t.Errorf("expected 'comment' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_GateApproved_CommentMatchNoPattern(t *testing.T) {
+	state := &State{
+		Event:  "gate.approved",
+		Params: map[string]any{"trigger": "comment_match"},
+	}
+	got := WaitStateGuidance(state, "")
+	if got == "" {
+		t.Error("expected non-empty guidance for comment_match gate")
+	}
+}
+
+func TestWaitStateGuidance_PlanUserReplied_WithApprovalPattern(t *testing.T) {
+	state := &State{
+		Event: "plan.user_replied",
+		Params: map[string]any{
+			"approval_pattern": `(?i)(LGTM|looks good|approved?|proceed|go ahead|ship it)`,
+		},
+	}
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "plan") {
+		t.Errorf("expected 'plan' in guidance, got %q", got)
+	}
+	// Should contain some example words extracted from the pattern
+	if !strings.Contains(got, "LGTM") && !strings.Contains(got, "looks good") && !strings.Contains(got, "approved") {
+		t.Errorf("expected pattern examples in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_PlanUserReplied_NoPattern(t *testing.T) {
+	state := &State{Event: "plan.user_replied"}
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "plan") {
+		t.Errorf("expected 'plan' in guidance, got %q", got)
+	}
+	if got == "" {
+		t.Error("expected non-empty guidance")
+	}
+}
+
+func TestWaitStateGuidance_PRReviewed_WithURL(t *testing.T) {
+	state := &State{Event: "pr.reviewed"}
+	prURL := "https://github.com/owner/repo/pull/42"
+	got := WaitStateGuidance(state, prURL)
+	if !strings.Contains(got, prURL) {
+		t.Errorf("expected PR URL in guidance, got %q", got)
+	}
+	if !strings.Contains(got, "review") {
+		t.Errorf("expected 'review' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_PRReviewed_NoURL(t *testing.T) {
+	state := &State{Event: "pr.reviewed"}
+	got := WaitStateGuidance(state, "")
+	if got == "" {
+		t.Error("expected non-empty guidance even without PR URL")
+	}
+	if !strings.Contains(got, "review") {
+		t.Errorf("expected 'review' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_AsanaInSection(t *testing.T) {
+	state := &State{
+		Event:  "asana.in_section",
+		Params: map[string]any{"section": "Doing"},
+	}
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "Doing") {
+		t.Errorf("expected section name in guidance, got %q", got)
+	}
+	if !strings.Contains(got, "Asana") {
+		t.Errorf("expected 'Asana' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_LinearInState(t *testing.T) {
+	state := &State{
+		Event:  "linear.in_state",
+		Params: map[string]any{"state": "In Progress"},
+	}
+	got := WaitStateGuidance(state, "")
+	if !strings.Contains(got, "In Progress") {
+		t.Errorf("expected state name in guidance, got %q", got)
+	}
+	if !strings.Contains(got, "Linear") {
+		t.Errorf("expected 'Linear' in guidance, got %q", got)
+	}
+}
+
+func TestWaitStateGuidance_AutomatedEvents(t *testing.T) {
+	automated := []string{"ci.complete", "ci.wait_for_checks", "pr.mergeable"}
+	for _, event := range automated {
+		state := &State{Event: event}
+		got := WaitStateGuidance(state, "")
+		if got != "" {
+			t.Errorf("event %q: expected empty guidance (automated), got %q", event, got)
+		}
+	}
+}
+
+func TestWaitStateGuidance_UnknownEvent(t *testing.T) {
+	state := &State{Event: "unknown.event"}
+	got := WaitStateGuidance(state, "")
+	if got != "" {
+		t.Errorf("expected empty guidance for unknown event, got %q", got)
+	}
+}
+
+func TestPatternExamples_Default(t *testing.T) {
+	pattern := `(?i)(LGTM|looks good|approved?|proceed|go ahead|ship it)`
+	got := patternExamples(pattern)
+	if len(got) == 0 {
+		t.Fatal("expected some examples")
+	}
+	if len(got) > 3 {
+		t.Errorf("expected at most 3 examples, got %d", len(got))
+	}
+	// All examples should be quoted
+	for _, ex := range got {
+		if !strings.HasPrefix(ex, `"`) {
+			t.Errorf("expected quoted example, got %q", ex)
+		}
+	}
+}
+
+func TestPatternExamples_Complex(t *testing.T) {
+	// Complex patterns should yield no examples
+	pattern := `^[A-Z]+$`
+	got := patternExamples(pattern)
+	// May return empty if all parts are complex
+	_ = got
+}


### PR DESCRIPTION
## Summary
When the daemon enters a wait state requiring human action (e.g. plan review, gate approval, PR review), it now posts a guidance comment on the issue tracker telling the user exactly what's needed to proceed. These guidance comments are tagged with markers and excluded from approval checks to prevent the daemon from accidentally approving itself.

## Changes
- Add `WaitStateGuidance()` in `internal/workflow/guidance.go` to generate human-readable guidance messages for each wait-state event type (gate.approved, plan.user_replied, pr.reviewed, asana.in_section, linear.in_state)
- Add `Guidance` field to `workflow.State` config to allow custom overrides or explicit suppression of guidance messages
- Add `postWaitGuidance()` in `internal/daemon/wait_guidance.go` to post idempotent guidance comments via GitHub, Asana, or Linear providers
- Reorder `executeSyncChain` in `processing.go` to post guidance **before** `AdvanceWorkItem`, ensuring the comment timestamp precedes `StepEnteredAt` and is naturally excluded by the time-based filter
- Add `isErgSystemComment()` helper to detect daemon-posted comments by their `[erg:step=…]` or `<!-- erg:step=… -->` markers
- Filter out system comments in `checkGateApproved` and `checkPlanUserReplied` event checkers to prevent self-approval
- Automated events (ci.complete, ci.wait_for_checks, pr.mergeable) are skipped since no human action is needed

## Test plan
- Run `go test -p=1 -count=1 ./internal/workflow/...` — tests for guidance message generation, pattern extraction, explicit suppression, and all event types
- Run `go test -p=1 -count=1 ./internal/daemon/...` — tests for `isErgSystemComment`, self-approval prevention regression tests for both `checkPlanUserReplied` and `checkGateApproved`, guidance posting for all provider types, and edge cases (unknown source, suppression, custom messages)
- Run full suite: `go test -p=1 -count=1 ./...`