### PR TITLE
Fix bugs, provider gaps, and UX issues across CLI

### DIFF
--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -92,9 +92,9 @@ reviewed your earlier plan and provided feedback. In that case:
 - Acknowledge the feedback and explain what changed
 
 POSTING THE PLAN:
-Use the comment_issue MCP tool to post the plan to the issue. Do NOT use "gh issue comment" or
-any other CLI command. The comment_issue tool routes through the daemon and handles authentication
-automatically.
+Use the comment_issue MCP tool to post the plan to the issue. Do NOT use CLI commands like
+"gh issue comment" or any other direct API calls. The comment_issue tool routes through the
+daemon and handles authentication automatically for all issue trackers (GitHub, Asana, Linear).
 
 CRITICAL: You MUST call comment_issue exactly once before finishing, in ALL cases — even if you
 believe the issue is already resolved by existing code or a prior commit. In that case, post a

--- a/internal/daemon/github_ops.go
+++ b/internal/daemon/github_ops.go
@@ -613,41 +613,39 @@ func (d *Daemon) unqueueIssue(ctx context.Context, item daemonstate.WorkItem, re
 // explanatory comment. All operations are best-effort — failures are logged but
 // do not block the workflow from advancing.
 func (d *Daemon) closeIssueGracefully(ctx context.Context, item daemonstate.WorkItem) {
-	if item.IssueRef.Source != "github" {
-		return
-	}
-
 	repoPath := d.resolveRepoPath(ctx, item)
 	if repoPath == "" {
 		return
 	}
 
-	log := d.logger.With("workItem", item.ID, "issue", item.IssueRef.ID)
-
-	issueNum, err := strconv.Atoi(item.IssueRef.ID)
-	if err != nil {
-		return
-	}
+	log := d.logger.With("workItem", item.ID, "issue", item.IssueRef.ID, "source", item.IssueRef.Source)
 
 	label := d.resolveQueueLabel(repoPath)
+	comment := "Closing this issue — no work was needed (the branch already has a merged PR or the coding session made no changes)."
 
 	opCtx, cancel := context.WithTimeout(ctx, timeoutStandardOp)
 	defer cancel()
 
-	// Remove queue label (best-effort)
-	if err := d.gitService.RemoveIssueLabel(opCtx, repoPath, issueNum, label); err != nil {
-		log.Debug("failed to remove queue label during graceful close", "error", err, "label", label)
+	// Try the provider registry first (works for GitHub, Asana, and Linear).
+	src := issues.Source(item.IssueRef.Source)
+	if d.issueRegistry != nil {
+		if p := d.issueRegistry.GetProvider(src); p != nil {
+			if pa, ok := p.(issues.ProviderActions); ok {
+				if err := pa.RemoveLabel(opCtx, repoPath, item.IssueRef.ID, label); err != nil {
+					log.Debug("failed to remove queue label during graceful close", "error", err, "label", label)
+				}
+				if err := pa.Comment(opCtx, repoPath, item.IssueRef.ID, comment); err != nil {
+					log.Debug("failed to comment during graceful close", "error", err)
+				}
+			}
+		}
 	}
 
-	// Comment explaining why we're closing
-	comment := "Closing this issue — no work was needed (the branch already has a merged PR or the coding session made no changes)."
-	if err := d.gitService.CommentOnIssue(opCtx, repoPath, issueNum, comment); err != nil {
-		log.Debug("failed to comment during graceful close", "error", err)
-	}
-
-	// Close the issue
-	if err := d.closeIssue(opCtx, item); err != nil {
-		log.Debug("failed to close issue during graceful close", "error", err)
+	// Close the issue (currently only supported for GitHub)
+	if src == issues.SourceGitHub {
+		if err := d.closeIssue(opCtx, item); err != nil {
+			log.Debug("failed to close issue during graceful close", "error", err)
+		}
 	}
 }
 

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -472,6 +472,52 @@ func (s *GitService) GetIssueComments(ctx context.Context, repoPath string, issu
 	return comments, nil
 }
 
+// IssueCommentWithID extends IssueComment with the GitHub database ID,
+// enabling comment updates via the REST API.
+type IssueCommentWithID struct {
+	ID        int64
+	Author    string
+	Body      string
+	CreatedAt time.Time
+}
+
+// GetIssueCommentsWithIDs fetches all comments on a GitHub issue using the REST API,
+// returning comments with their database IDs (needed for update operations).
+func (s *GitService) GetIssueCommentsWithIDs(ctx context.Context, repoPath string, issueNumber int) ([]IssueCommentWithID, error) {
+	output, err := s.executor.Output(ctx, repoPath, "gh", "api",
+		fmt.Sprintf("repos/:owner/:repo/issues/%d/comments", issueNumber),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh api list issue comments failed: %w", err)
+	}
+
+	var raw []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(output, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse issue comments: %w", err)
+	}
+
+	comments := make([]IssueCommentWithID, 0, len(raw))
+	for _, c := range raw {
+		if c.Body == "" {
+			continue
+		}
+		comments = append(comments, IssueCommentWithID{
+			ID:        c.ID,
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+	return comments, nil
+}
+
 // GitHubIssue represents a GitHub issue fetched via the gh CLI
 type GitHubIssue struct {
 	Number int    `json:"number"`

--- a/internal/issues/asana.go
+++ b/internal/issues/asana.go
@@ -393,7 +393,10 @@ func (p *AsanaProvider) RemoveLabel(ctx context.Context, repoPath string, issueI
 
 	// Remove the tag from the task.
 	removeURL := fmt.Sprintf("%s/tasks/%s/removeTag", p.apiBase, issueID)
-	tagJSON, _ := json.Marshal(tagGID)
+	tagJSON, err := json.Marshal(tagGID)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tag GID: %w", err)
+	}
 	removeBody := fmt.Sprintf(`{"data":{"tag":%s}}`, tagJSON)
 
 	return apiRequest(ctx, p.httpClient, http.MethodPost, removeURL, strings.NewReader(removeBody),
@@ -584,7 +587,10 @@ func (p *AsanaProvider) MoveToSection(ctx context.Context, repoPath string, issu
 	}
 
 	addTaskURL := fmt.Sprintf("%s/sections/%s/addTask", p.apiBase, sectionGID)
-	taskJSON, _ := json.Marshal(issueID)
+	taskJSON, err := json.Marshal(issueID)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task ID: %w", err)
+	}
 	reqBody := fmt.Sprintf(`{"data":{"task":%s}}`, taskJSON)
 
 	return apiRequest(ctx, p.httpClient, http.MethodPost, addTaskURL, strings.NewReader(reqBody),
@@ -600,7 +606,10 @@ func (p *AsanaProvider) Comment(ctx context.Context, repoPath string, issueID st
 	}
 
 	storiesURL := fmt.Sprintf("%s/tasks/%s/stories", p.apiBase, issueID)
-	textJSON, _ := json.Marshal(body)
+	textJSON, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal comment body: %w", err)
+	}
 	reqBody := fmt.Sprintf(`{"data":{"text":%s}}`, textJSON)
 
 	return apiRequest(ctx, p.httpClient, http.MethodPost, storiesURL, strings.NewReader(reqBody),
@@ -616,7 +625,10 @@ func (p *AsanaProvider) UpdateComment(ctx context.Context, repoPath string, issu
 	}
 
 	storyURL := fmt.Sprintf("%s/stories/%s", p.apiBase, commentID)
-	textJSON, _ := json.Marshal(body)
+	textJSON, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal comment body: %w", err)
+	}
 	reqBody := fmt.Sprintf(`{"data":{"text":%s}}`, textJSON)
 
 	return apiRequest(ctx, p.httpClient, http.MethodPut, storyURL, strings.NewReader(reqBody),

--- a/internal/issues/github.go
+++ b/internal/issues/github.go
@@ -87,6 +87,51 @@ func (p *GitHubProvider) Comment(ctx context.Context, repoPath string, issueID s
 	return p.gitService.CommentOnIssue(ctx, repoPath, issueNum, body)
 }
 
+// CheckIssueHasLabel returns true if the GitHub issue has the given label.
+// Implements ProviderGateChecker.
+func (p *GitHubProvider) CheckIssueHasLabel(ctx context.Context, repoPath string, issueID string, label string) (bool, error) {
+	issueNum, err := strconv.Atoi(issueID)
+	if err != nil {
+		return false, fmt.Errorf("invalid GitHub issue ID %q: %w", issueID, err)
+	}
+	return p.gitService.CheckIssueHasLabel(ctx, repoPath, issueNum, label)
+}
+
+// GetIssueComments returns all comments on a GitHub issue, ordered oldest first.
+// Uses both the gh CLI and REST API to return comments with IDs (needed for
+// ProviderCommentUpdater support).
+// Implements ProviderGateChecker.
+func (p *GitHubProvider) GetIssueComments(ctx context.Context, repoPath string, issueID string) ([]IssueComment, error) {
+	issueNum, err := strconv.Atoi(issueID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid GitHub issue ID %q: %w", issueID, err)
+	}
+	gitComments, err := p.gitService.GetIssueCommentsWithIDs(ctx, repoPath, issueNum)
+	if err != nil {
+		return nil, err
+	}
+	comments := make([]IssueComment, len(gitComments))
+	for i, gc := range gitComments {
+		comments[i] = IssueComment{
+			ID:        strconv.FormatInt(gc.ID, 10),
+			Author:    gc.Author,
+			Body:      gc.Body,
+			CreatedAt: gc.CreatedAt,
+		}
+	}
+	return comments, nil
+}
+
+// UpdateComment updates an existing GitHub issue comment by its ID.
+// Implements ProviderCommentUpdater.
+func (p *GitHubProvider) UpdateComment(ctx context.Context, repoPath string, issueID string, commentID string, body string) error {
+	id, err := strconv.ParseInt(commentID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid GitHub comment ID %q: %w", commentID, err)
+	}
+	return p.gitService.UpdateIssueComment(ctx, repoPath, id, body)
+}
+
 // GetIssueNumber returns the issue number as an int (for backwards compatibility).
 // Returns 0 if the ID is not a valid number.
 func GetIssueNumber(issue Issue) int {

--- a/internal/issues/github_test.go
+++ b/internal/issues/github_test.go
@@ -143,6 +143,115 @@ func TestGitHubProvider_ImplementsProviderActions(t *testing.T) {
 	var _ ProviderActions = (*GitHubProvider)(nil)
 }
 
+func TestGitHubProvider_ImplementsProviderGateChecker(t *testing.T) {
+	var _ ProviderGateChecker = (*GitHubProvider)(nil)
+}
+
+func TestGitHubProvider_ImplementsProviderCommentUpdater(t *testing.T) {
+	var _ ProviderCommentUpdater = (*GitHubProvider)(nil)
+}
+
+func TestGitHubProvider_CheckIssueHasLabel(t *testing.T) {
+	mock := exec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"issue", "view", "42", "--json", "labels"},
+		exec.MockResponse{Stdout: []byte(`{"labels":[{"name":"queued"},{"name":"bug"}]}`)})
+
+	gitSvc := git.NewGitServiceWithExecutor(mock)
+	p := NewGitHubProvider(gitSvc)
+
+	has, err := p.CheckIssueHasLabel(context.Background(), "/repo", "42", "queued")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Error("expected issue to have label 'queued'")
+	}
+}
+
+func TestGitHubProvider_CheckIssueHasLabel_NotFound(t *testing.T) {
+	mock := exec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"issue", "view", "42", "--json", "labels"},
+		exec.MockResponse{Stdout: []byte(`{"labels":[{"name":"bug"}]}`)})
+
+	gitSvc := git.NewGitServiceWithExecutor(mock)
+	p := NewGitHubProvider(gitSvc)
+
+	has, err := p.CheckIssueHasLabel(context.Background(), "/repo", "42", "queued")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Error("expected issue to NOT have label 'queued'")
+	}
+}
+
+func TestGitHubProvider_CheckIssueHasLabel_InvalidID(t *testing.T) {
+	p := NewGitHubProvider(nil)
+
+	_, err := p.CheckIssueHasLabel(context.Background(), "/repo", "not-a-number", "queued")
+	if err == nil {
+		t.Error("expected error for invalid issue ID")
+	}
+}
+
+func TestGitHubProvider_GetIssueComments(t *testing.T) {
+	mock := exec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"},
+		exec.MockResponse{Stdout: []byte(`[{"id":100,"body":"hello","user":{"login":"alice"},"created_at":"2024-01-01T00:00:00Z"},{"id":101,"body":"world","user":{"login":"bob"},"created_at":"2024-01-02T00:00:00Z"}]`)})
+
+	gitSvc := git.NewGitServiceWithExecutor(mock)
+	p := NewGitHubProvider(gitSvc)
+
+	comments, err := p.GetIssueComments(context.Background(), "/repo", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(comments))
+	}
+	if comments[0].ID != "100" {
+		t.Errorf("expected comment ID '100', got '%s'", comments[0].ID)
+	}
+	if comments[0].Author != "alice" {
+		t.Errorf("expected author 'alice', got '%s'", comments[0].Author)
+	}
+	if comments[0].Body != "hello" {
+		t.Errorf("expected body 'hello', got '%s'", comments[0].Body)
+	}
+}
+
+func TestGitHubProvider_GetIssueComments_InvalidID(t *testing.T) {
+	p := NewGitHubProvider(nil)
+
+	_, err := p.GetIssueComments(context.Background(), "/repo", "not-a-number")
+	if err == nil {
+		t.Error("expected error for invalid issue ID")
+	}
+}
+
+func TestGitHubProvider_UpdateComment(t *testing.T) {
+	mock := exec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"api", "--method", "PATCH", "repos/:owner/:repo/issues/comments/100", "-f", "body=updated"},
+		exec.MockResponse{})
+
+	gitSvc := git.NewGitServiceWithExecutor(mock)
+	p := NewGitHubProvider(gitSvc)
+
+	err := p.UpdateComment(context.Background(), "/repo", "42", "100", "updated")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGitHubProvider_UpdateComment_InvalidCommentID(t *testing.T) {
+	p := NewGitHubProvider(nil)
+
+	err := p.UpdateComment(context.Background(), "/repo", "42", "not-a-number", "body")
+	if err == nil {
+		t.Error("expected error for invalid comment ID")
+	}
+}
+
 func TestGetIssueNumber(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/issues/linear.go
+++ b/internal/issues/linear.go
@@ -393,6 +393,9 @@ func (p *LinearProvider) RemoveLabel(ctx context.Context, repoPath string, issue
 	}, "", &updateResp); err != nil {
 		return fmt.Errorf("failed to update issue labels: %w", err)
 	}
+	if !updateResp.Data.IssueUpdate.Success {
+		return fmt.Errorf("Linear API returned success=false for label update on issue %q", issueID)
+	}
 
 	return nil
 }
@@ -431,6 +434,9 @@ func (p *LinearProvider) Comment(ctx context.Context, repoPath string, issueID s
 	}, "", &commentResp); err != nil {
 		return fmt.Errorf("failed to create comment: %w", err)
 	}
+	if !commentResp.Data.CommentCreate.Success {
+		return fmt.Errorf("Linear API returned success=false for comment on issue %q", issueID)
+	}
 
 	return nil
 }
@@ -450,6 +456,9 @@ func (p *LinearProvider) UpdateComment(ctx context.Context, repoPath string, iss
 		"body": body,
 	}, "", &updateResp); err != nil {
 		return fmt.Errorf("failed to update comment: %w", err)
+	}
+	if !updateResp.Data.CommentUpdate.Success {
+		return fmt.Errorf("Linear API returned success=false for comment update %q", commentID)
 	}
 	return nil
 }
@@ -582,6 +591,9 @@ func (p *LinearProvider) MoveToSection(ctx context.Context, repoPath string, iss
 		"stateId": targetStateID,
 	}, "", &updateResp); err != nil {
 		return fmt.Errorf("failed to update issue state: %w", err)
+	}
+	if !updateResp.Data.IssueUpdate.Success {
+		return fmt.Errorf("Linear API returned success=false for state update on issue %q", issueID)
 	}
 
 	return nil

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -31,7 +31,7 @@ type SessionWorker struct {
 	once   sync.Once
 
 	exitErr          atomic.Pointer[error] // written from run() goroutine; read externally — use atomics
-	apiErrorInStream bool                  // Set when an API error is detected in streamed content
+	apiErrorInStream atomic.Bool           // Set when an API error is detected in streamed content
 
 	// Per-session limit overrides (zero = use host defaults)
 	overrideMaxTurns    int
@@ -185,7 +185,7 @@ func (w *SessionWorker) run() {
 
 		// Check if the response contained an API error (e.g., 500 errors
 		// emitted as streamed text rather than as chunk.Error)
-		if w.apiErrorInStream {
+		if w.apiErrorInStream.Load() {
 			apiErr := fmt.Errorf("API error detected in response stream")
 			w.exitErr.Store(&apiErr)
 			log.Warn("worker stopping due to API error in stream")
@@ -367,7 +367,7 @@ func (w *SessionWorker) handleStreaming(chunk claude.ResponseChunk) {
 		// the Anthropic API that the runner surfaces as text rather than
 		// as chunk.Error).
 		if isAPIErrorContent(chunk.Content) || isSessionNotFoundContent(chunk.Content) {
-			w.apiErrorInStream = true
+			w.apiErrorInStream.Store(true)
 		}
 
 		// Log first 100 chars of content for debugging
@@ -421,7 +421,7 @@ func isSessionNotFoundContent(content string) bool {
 
 // handleDone handles completion of a streaming response.
 func (w *SessionWorker) handleDone() {
-	log := w.host.Logger().With("sessionID", w.sessionID, "turn", w.turns)
+	log := w.host.Logger().With("sessionID", w.sessionID, "turn", w.turns.Load())
 	log.Debug("response completed")
 
 	// Mark session as started if needed

--- a/internal/workflow/validate.go
+++ b/internal/workflow/validate.go
@@ -246,6 +246,11 @@ func validateState(name string, state *State, allStates map[string]*State) []Val
 				Field:   prefix + ".next",
 				Message: "next is required for pass states",
 			})
+		} else if _, ok := allStates[state.Next]; !ok {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".next",
+				Message: fmt.Sprintf("references non-existent state %q", state.Next),
+			})
 		}
 
 	case StateTypeSucceed, StateTypeFail:

--- a/internal/workflow/validate_test.go
+++ b/internal/workflow/validate_test.go
@@ -446,6 +446,17 @@ func TestValidate(t *testing.T) {
 			wantFields: []string{"states.setup.next"},
 		},
 		{
+			name: "pass state next references non-existent state",
+			cfg: &Config{
+				Start:  "setup",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"setup": {Type: StateTypePass, Next: "does_not_exist", Data: map[string]any{"key": "val"}},
+				},
+			},
+			wantFields: []string{"states.setup.next"},
+		},
+		{
 			name: "valid choice state",
 			cfg: &Config{
 				Start:  "check",


### PR DESCRIPTION
- Add ProviderGateChecker and ProviderCommentUpdater to GitHub provider, closing feature parity gap with Asana/Linear (gate conditions and idempotent comment updates now work for GitHub issues)
- Validate Linear API mutation success flags in RemoveLabel, Comment, UpdateComment, and MoveToSection (previously ignored success=false)
- Check json.Marshal errors in Asana RemoveLabel, MoveToSection, Comment, and UpdateComment (previously silently sent malformed JSON on error)
- Make closeIssueGracefully work for all providers via ProviderActions registry instead of GitHub-only hardcoded path
- Fix DefaultPlanningSystemPrompt to reference all issue trackers instead of only GitHub CLI commands
- Add pass state next-state existence validation in workflow engine (previously allowed referencing non-existent states)
- Fix apiErrorInStream data race in SessionWorker by using atomic.Bool instead of plain bool accessed from multiple goroutines
- Fix pre-existing vet warning: pass atomic.Int32 value (not copy) to logger in handleDone

https://claude.ai/code/session_015Pjt3echwfUdwb43ut3enX