### PR TITLE
feat(cli): add --workflow flag to override default workflow config path

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -26,10 +26,11 @@ import (
 )
 
 var (
-	agentOnce       bool
-	agentRepo       string
-	agentForeground bool
-	agentDaemonMode bool // hidden --_daemon flag for re-exec child
+	agentOnce         bool
+	agentRepo         string
+	agentForeground   bool
+	agentDaemonMode   bool   // hidden --_daemon flag for re-exec child
+	agentWorkflowFile string // optional explicit workflow config file path
 )
 
 // osExecutable is the function used to resolve the current binary path.
@@ -41,9 +42,11 @@ func init() {
 	rootCmd.Flags().BoolVar(&agentOnce, "once", false, "Run one tick and exit (vs continuous daemon)")
 	rootCmd.Flags().StringVar(&agentRepo, "repo", "", "Repo to poll (owner/repo or filesystem path)")
 	rootCmd.Flags().BoolVar(&agentDaemonMode, "_daemon", false, "Internal: run as detached daemon child")
-	rootCmd.Flags().MarkHidden("_daemon") //nolint:errcheck
-	rootCmd.Flags().MarkHidden("once")    //nolint:errcheck
-	rootCmd.Flags().MarkHidden("repo")    //nolint:errcheck
+	rootCmd.Flags().StringVar(&agentWorkflowFile, "_workflow", "", "Internal: workflow file path passed to daemon child")
+	rootCmd.Flags().MarkHidden("_daemon")   //nolint:errcheck
+	rootCmd.Flags().MarkHidden("_workflow") //nolint:errcheck
+	rootCmd.Flags().MarkHidden("once")      //nolint:errcheck
+	rootCmd.Flags().MarkHidden("repo")      //nolint:errcheck
 }
 
 func runAgent(cmd *cobra.Command, args []string) error {
@@ -123,7 +126,7 @@ func daemonize(cmd *cobra.Command, args []string) error {
 	buildLogger := logger.Get()
 
 	// Load workflow config + build image
-	wfCfg, err := workflow.LoadAndMerge(agentRepo)
+	wfCfg, err := workflow.LoadAndMergeWithFile(agentRepo, agentWorkflowFile)
 	if err != nil {
 		return fmt.Errorf("error loading workflow config: %w", err)
 	}
@@ -152,7 +155,7 @@ func daemonize(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build args for re-exec
-	childArgs := buildDaemonArgs(agentRepo, agentOnce)
+	childArgs := buildDaemonArgs(agentRepo, agentOnce, agentWorkflowFile)
 
 	// Re-exec self with --_daemon
 	self, err := osExecutable()
@@ -208,10 +211,13 @@ func daemonize(cmd *cobra.Command, args []string) error {
 }
 
 // buildDaemonArgs constructs the args slice for the re-exec'd child process.
-func buildDaemonArgs(repo string, once bool) []string {
+func buildDaemonArgs(repo string, once bool, workflowFile string) []string {
 	args := []string{"--_daemon", "--repo", repo}
 	if once {
 		args = append(args, "--once")
+	}
+	if workflowFile != "" {
+		args = append(args, "--_workflow", workflowFile)
 	}
 	return args
 }
@@ -334,7 +340,7 @@ func runForeground(_ *cobra.Command, _ []string) error {
 	}()
 
 	// Load workflow config + build image
-	wfCfg, err := workflow.LoadAndMerge(agentRepo)
+	wfCfg, err := workflow.LoadAndMergeWithFile(agentRepo, agentWorkflowFile)
 	if err != nil {
 		return fmt.Errorf("error loading workflow config: %w", err)
 	}
@@ -402,7 +408,7 @@ func runDaemonWithLogger(ctx context.Context, daemonLogger *slog.Logger, preacqu
 	gitSvc := git.NewGitService()
 	sessSvc := session.NewSessionService()
 
-	wfCfg, err := workflow.LoadAndMerge(agentRepo)
+	wfCfg, err := workflow.LoadAndMergeWithFile(agentRepo, agentWorkflowFile)
 	if err != nil {
 		return fmt.Errorf("error loading workflow config: %w", err)
 	}
@@ -471,6 +477,9 @@ func runDaemonWithLogger(ctx context.Context, daemonLogger *slog.Logger, preacqu
 	}
 	if len(preacquiredLock) > 0 && preacquiredLock[0] != nil {
 		opts = append(opts, daemon.WithPreacquiredLock(preacquiredLock[0]))
+	}
+	if agentWorkflowFile != "" {
+		opts = append(opts, daemon.WithWorkflowFile(agentWorkflowFile))
 	}
 
 	d := daemon.New(cfg, gitSvc, sessSvc, issueRegistry, daemonLogger, opts...)

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -219,7 +219,7 @@ func TestRuntimeStartHint_ColimaNotInstalled(t *testing.T) {
 // ---- buildDaemonArgs ----
 
 func TestBuildDaemonArgs_Basic(t *testing.T) {
-	args := buildDaemonArgs("owner/repo", false)
+	args := buildDaemonArgs("owner/repo", false, "")
 	if len(args) != 3 {
 		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 	}
@@ -232,7 +232,7 @@ func TestBuildDaemonArgs_Basic(t *testing.T) {
 }
 
 func TestBuildDaemonArgs_WithOnce(t *testing.T) {
-	args := buildDaemonArgs("owner/repo", true)
+	args := buildDaemonArgs("owner/repo", true, "")
 	if len(args) != 4 {
 		t.Fatalf("expected 4 args, got %d: %v", len(args), args)
 	}
@@ -244,9 +244,31 @@ func TestBuildDaemonArgs_WithOnce(t *testing.T) {
 
 func TestBuildDaemonArgs_HiddenFlagAppended(t *testing.T) {
 	// Verify --_daemon is always the first arg
-	args := buildDaemonArgs("/path/to/repo", false)
+	args := buildDaemonArgs("/path/to/repo", false, "")
 	if args[0] != "--_daemon" {
 		t.Errorf("expected '--_daemon' as first arg, got %q", args[0])
+	}
+}
+
+func TestBuildDaemonArgs_WithWorkflowFile(t *testing.T) {
+	args := buildDaemonArgs("owner/repo", false, "/custom/workflow.yaml")
+	if !slices.Contains(args, "--_workflow") {
+		t.Errorf("expected '--_workflow' in args: %v", args)
+	}
+	idx := slices.Index(args, "--_workflow")
+	if idx < 0 || idx+1 >= len(args) {
+		t.Fatalf("--_workflow flag has no value in args: %v", args)
+	}
+	if args[idx+1] != "/custom/workflow.yaml" {
+		t.Errorf("expected '/custom/workflow.yaml', got %q", args[idx+1])
+	}
+}
+
+func TestBuildDaemonArgs_NoWorkflowFile(t *testing.T) {
+	// When workflowFile is empty, --_workflow should not appear in args.
+	args := buildDaemonArgs("owner/repo", false, "")
+	if slices.Contains(args, "--_workflow") {
+		t.Errorf("expected no '--_workflow' in args when empty: %v", args)
 	}
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -5,9 +5,10 @@ import (
 )
 
 var (
-	startRepo       string
-	startForeground bool
-	startOnce       bool
+	startRepo         string
+	startForeground   bool
+	startOnce         bool
+	startWorkflowFile string
 )
 
 var startCmd = &cobra.Command{
@@ -31,6 +32,7 @@ func init() {
 	startCmd.Flags().StringVar(&startRepo, "repo", "", "Repo to poll (owner/repo or filesystem path)")
 	startCmd.Flags().BoolVarP(&startForeground, "foreground", "f", false, "Stay in foreground with live status display")
 	startCmd.Flags().BoolVar(&startOnce, "once", false, "Run one tick and exit (vs continuous daemon)")
+	startCmd.Flags().StringVar(&startWorkflowFile, "workflow", "", "Path to workflow config file (default: <repo>/.erg/workflow.yaml)")
 	rootCmd.AddCommand(startCmd)
 }
 
@@ -39,6 +41,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	agentRepo = startRepo
 	agentForeground = startForeground
 	agentOnce = startOnce
+	agentWorkflowFile = startWorkflowFile
 
 	// --once implies foreground
 	if agentOnce {

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -56,6 +56,16 @@ func TestStartOnceImpliesForeground(t *testing.T) {
 	}
 }
 
+func TestStartCmdWorkflowFlagExists(t *testing.T) {
+	flag := startCmd.Flags().Lookup("workflow")
+	if flag == nil {
+		t.Fatal("expected --workflow flag on start command")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("expected default value to be empty, got %q", flag.DefValue)
+	}
+}
+
 func TestStartCmdRegisteredOnRoot(t *testing.T) {
 	found := false
 	for _, sub := range rootCmd.Commands() {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -62,6 +62,9 @@ type Daemon struct {
 	dockerDown        bool
 	dockerDownLogged  bool
 	dockerHealthCheck func() error // injectable for testing; nil means use default
+
+	// Workflow
+	workflowFile string // optional explicit workflow config file path
 }
 
 // Option configures the daemon.
@@ -116,6 +119,12 @@ func WithMergeMethod(method string) Option {
 // by the parent process. The daemon will adopt it instead of acquiring a new one.
 func WithPreacquiredLock(lock *daemonstate.DaemonLock) Option {
 	return func(d *Daemon) { d.lock = lock }
+}
+
+// WithWorkflowFile sets an explicit workflow config file path, overriding the
+// default <repo>/.erg/workflow.yaml discovery.
+func WithWorkflowFile(file string) Option {
+	return func(d *Daemon) { d.workflowFile = file }
 }
 
 // New creates a new daemon.
@@ -288,7 +297,7 @@ func (d *Daemon) loadWorkflowConfigs() {
 	d.engines = make(map[string]*workflow.Engine)
 
 	for _, repoPath := range d.config.GetRepos() {
-		cfg, err := workflow.LoadAndMerge(repoPath)
+		cfg, err := workflow.LoadAndMergeWithFile(repoPath, d.workflowFile)
 		if err != nil {
 			d.logger.Warn("failed to load workflow config", "repo", repoPath, "error", err)
 			continue

--- a/internal/workflow/loader.go
+++ b/internal/workflow/loader.go
@@ -68,10 +68,53 @@ func isOldFormat(data []byte) bool {
 	return false
 }
 
+// LoadFile reads and parses a workflow config from an explicit file path.
+// Returns nil, nil if the file does not exist.
+func LoadFile(filePath string) (*Config, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read workflow config: %w", err)
+	}
+
+	if isOldFormat(data) {
+		return nil, fmt.Errorf(
+			"workflow config uses the old flat format which is no longer supported. " +
+				"Please migrate to the new step-functions format. " +
+				"Run `erg workflow init` to see the new format, " +
+				"or see https://github.com/zhubert/erg for migration docs",
+		)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse workflow config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
 // LoadAndMerge loads the workflow config and merges with defaults.
 // If no workflow file exists, returns the default config.
 func LoadAndMerge(repoPath string) (*Config, error) {
-	cfg, err := Load(repoPath)
+	return LoadAndMergeWithFile(repoPath, "")
+}
+
+// LoadAndMergeWithFile loads the workflow config and merges with defaults.
+// If workflowFile is non-empty, it is used as the explicit path to the config
+// file instead of the default <repoPath>/.erg/workflow.yaml.
+func LoadAndMergeWithFile(repoPath, workflowFile string) (*Config, error) {
+	var (
+		cfg *Config
+		err error
+	)
+	if workflowFile != "" {
+		cfg, err = LoadFile(workflowFile)
+	} else {
+		cfg, err = Load(repoPath)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -249,6 +249,133 @@ states:
 	}
 }
 
+func TestLoadFile_NotExists(t *testing.T) {
+	cfg, err := LoadFile("/nonexistent/path/workflow.yaml")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if cfg != nil {
+		t.Error("expected nil config for missing file")
+	}
+}
+
+func TestLoadFile_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := `
+workflow: test-flow
+start: coding
+
+source:
+  provider: github
+  filter:
+    label: "ready"
+
+states:
+  coding:
+    type: task
+    action: ai.code
+    next: done
+    error: failed
+  done:
+    type: succeed
+  failed:
+    type: fail
+`
+	fp := filepath.Join(dir, "my-workflow.yaml")
+	if err := os.WriteFile(fp, []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFile(fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.Source.Provider != "github" {
+		t.Errorf("provider: got %q, want github", cfg.Source.Provider)
+	}
+	if cfg.Source.Filter.Label != "ready" {
+		t.Errorf("label: got %q, want ready", cfg.Source.Filter.Label)
+	}
+}
+
+func TestLoadFile_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(fp, []byte("{{invalid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFile(fp)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoadAndMergeWithFile_UsesExplicitPath(t *testing.T) {
+	// Write a workflow file to a non-default location.
+	dir := t.TempDir()
+	yamlContent := `
+workflow: custom-flow
+start: coding
+
+source:
+  provider: linear
+  filter:
+    team: "custom-team"
+
+states:
+  coding:
+    type: task
+    action: ai.code
+    next: done
+    error: failed
+  done:
+    type: succeed
+  failed:
+    type: fail
+`
+	customFile := filepath.Join(dir, "custom-workflow.yaml")
+	if err := os.WriteFile(customFile, []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// repoPath points to an empty dir (no .erg/workflow.yaml) — proves the
+	// explicit file path is used rather than the default location.
+	emptyRepo := t.TempDir()
+	cfg, err := LoadAndMergeWithFile(emptyRepo, customFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.Source.Provider != "linear" {
+		t.Errorf("provider: got %q, want linear", cfg.Source.Provider)
+	}
+	if cfg.Source.Filter.Team != "custom-team" {
+		t.Errorf("team: got %q, want custom-team", cfg.Source.Filter.Team)
+	}
+}
+
+func TestLoadAndMergeWithFile_EmptyPathFallsBackToDefault(t *testing.T) {
+	// With an empty workflowFile, LoadAndMergeWithFile behaves like LoadAndMerge.
+	dir := t.TempDir()
+	cfg, err := LoadAndMergeWithFile(dir, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected default config")
+	}
+	// Should return the default provider (github)
+	if cfg.Source.Provider != "github" {
+		t.Errorf("expected default provider github, got %q", cfg.Source.Provider)
+	}
+}
+
 func TestLoadAndMerge_PartialFile(t *testing.T) {
 	dir := t.TempDir()
 	ergDir := filepath.Join(dir, ".erg")


### PR DESCRIPTION
## Summary
Adds a `--workflow` flag to `erg start` that allows specifying an explicit workflow config file path instead of relying on the default `<repo>/.erg/workflow.yaml` discovery.

## Changes
- Add `--workflow` flag to the `start` command (public) and `--_workflow` hidden flag for daemon re-exec
- Add `LoadFile()` function to load workflow config from an explicit file path
- Add `LoadAndMergeWithFile()` that accepts an optional explicit path, falling back to default discovery when empty
- Refactor `LoadAndMerge()` to delegate to `LoadAndMergeWithFile()` with empty path
- Add `WithWorkflowFile()` daemon option to propagate the workflow file path
- Pass workflow file through `buildDaemonArgs` for daemon re-exec
- Update all `LoadAndMerge` call sites to use `LoadAndMergeWithFile`

## Test plan
- New unit tests for `LoadFile` (missing file, valid file, invalid YAML)
- New unit tests for `LoadAndMergeWithFile` (explicit path, empty fallback)
- New tests for `buildDaemonArgs` with/without workflow file
- New test verifying `--workflow` flag exists on start command
- Run `go test -p=1 -count=1 ./...` to verify all tests pass