### PR TITLE
Fix long-running stability issues

### DIFF
--- a/internal/daemon/actions.go
+++ b/internal/daemon/actions.go
@@ -1308,7 +1308,13 @@ func (d *Daemon) postWebhook(ctx context.Context, item daemonstate.WorkItem, par
 	if err != nil {
 		return 0, fmt.Errorf("webhook POST failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain any remaining body so the underlying TCP connection can be reused
+		// by the connection pool. Without this, partially-read responses cause
+		// the transport to discard the connection.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode != expectedStatus {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -61,7 +61,7 @@ type Daemon struct {
 	// Docker health tracking
 	dockerDown        bool
 	dockerDownLogged  bool
-	dockerHealthCheck func() error // injectable for testing; nil means use default
+	dockerHealthCheck func(context.Context) error // injectable for testing; nil means use default
 
 	// Workflow
 	workflowFile string // optional explicit workflow config file path
@@ -243,7 +243,7 @@ func (d *Daemon) notifyWorkerDone() {
 // tick performs one iteration of the daemon event loop.
 func (d *Daemon) tick(ctx context.Context) {
 	d.collectCompletedWorkers(ctx) // Always: detect finished sessions
-	dockerOK := d.checkDockerHealth()
+	dockerOK := d.checkDockerHealth(ctx)
 	if dockerOK {
 		d.processRetryItems(ctx)    // Re-execute items whose retry delay has elapsed
 		d.processIdleSyncItems(ctx) // Execute items idle on sync task steps (e.g. after recovery)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -55,7 +55,7 @@ func testDaemon(cfg *config.Config) *Daemon {
 	d := New(cfg, gitSvc, sessSvc, registry, logger)
 	d.sessionMgr.SetSkipMessageLoad(true)
 	d.state = daemonstate.NewDaemonState("/test/repo")
-	d.dockerHealthCheck = func() error { return nil } // tests assume Docker is available
+	d.dockerHealthCheck = func(context.Context) error { return nil } // tests assume Docker is available
 	return d
 }
 
@@ -69,7 +69,7 @@ func testDaemonWithExec(cfg *config.Config, mockExec *exec.MockExecutor) *Daemon
 	d := New(cfg, gitSvc, sessSvc, registry, logger)
 	d.sessionMgr.SetSkipMessageLoad(true)
 	d.state = daemonstate.NewDaemonState("/test/repo")
-	d.dockerHealthCheck = func() error { return nil } // tests assume Docker is available
+	d.dockerHealthCheck = func(context.Context) error { return nil } // tests assume Docker is available
 	return d
 }
 
@@ -2092,7 +2092,7 @@ func TestTick_SkipsDispatchWhenDockerDown(t *testing.T) {
 	d.repoFilter = "/test/repo"
 
 	// Inject a health check that reports Docker as down
-	d.dockerHealthCheck = func() error {
+	d.dockerHealthCheck = func(context.Context) error {
 		return errors.New("docker not available")
 	}
 
@@ -2140,7 +2140,7 @@ func TestTick_ResumesWhenDockerRecovers(t *testing.T) {
 	d.repoFilter = "/test/repo"
 
 	// Start with Docker down
-	d.dockerHealthCheck = func() error {
+	d.dockerHealthCheck = func(context.Context) error {
 		return errors.New("docker not available")
 	}
 
@@ -2160,7 +2160,7 @@ func TestTick_ResumesWhenDockerRecovers(t *testing.T) {
 	}
 
 	// Now Docker recovers
-	d.dockerHealthCheck = func() error { return nil }
+	d.dockerHealthCheck = func(context.Context) error { return nil }
 
 	// Second tick: Docker is back
 	d.tick(context.Background())
@@ -2182,12 +2182,12 @@ func TestCheckDockerHealth_LogsOnceWhenDown(t *testing.T) {
 	cfg := testConfig()
 	d := testDaemon(cfg)
 
-	d.dockerHealthCheck = func() error {
+	d.dockerHealthCheck = func(context.Context) error {
 		return errors.New("docker daemon not running")
 	}
 
 	// First check — should set both flags
-	ok := d.checkDockerHealth()
+	ok := d.checkDockerHealth(context.Background())
 	if ok {
 		t.Error("expected checkDockerHealth to return false when Docker is down")
 	}
@@ -2199,7 +2199,7 @@ func TestCheckDockerHealth_LogsOnceWhenDown(t *testing.T) {
 	}
 
 	// Second check — flags should remain, no additional logging
-	ok = d.checkDockerHealth()
+	ok = d.checkDockerHealth(context.Background())
 	if ok {
 		t.Error("expected checkDockerHealth to still return false")
 	}
@@ -2220,9 +2220,9 @@ func TestCheckDockerHealth_ClearsFlagsOnRecovery(t *testing.T) {
 	// Simulate Docker down
 	d.dockerDown = true
 	d.dockerDownLogged = true
-	d.dockerHealthCheck = func() error { return nil }
+	d.dockerHealthCheck = func(context.Context) error { return nil }
 
-	ok := d.checkDockerHealth()
+	ok := d.checkDockerHealth(context.Background())
 	if !ok {
 		t.Error("expected checkDockerHealth to return true when Docker recovers")
 	}
@@ -2411,9 +2411,9 @@ func TestDockerRecovery_ResumesDockerPendingItems(t *testing.T) {
 	d.dockerDownLogged = true
 
 	// Docker recovers
-	d.dockerHealthCheck = func() error { return nil }
+	d.dockerHealthCheck = func(context.Context) error { return nil }
 
-	ok := d.checkDockerHealth()
+	ok := d.checkDockerHealth(context.Background())
 	if !ok {
 		t.Fatal("expected checkDockerHealth to return true when Docker recovers")
 	}
@@ -2449,7 +2449,7 @@ func TestDockerDownAndRecovery_FullCycle(t *testing.T) {
 	d.loadWorkflowConfigs()
 
 	dockerUp := true
-	d.dockerHealthCheck = func() error {
+	d.dockerHealthCheck = func(context.Context) error {
 		if dockerUp {
 			return nil
 		}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -94,12 +94,23 @@ func (d *Daemon) saveConfig(where string) {
 	}
 }
 
+// terminalWorkItemMaxAge is how long completed/failed work items are retained
+// before being pruned from the state. 7 days provides ample time for debugging
+// while preventing unbounded state growth in long-running daemons.
+const terminalWorkItemMaxAge = 7 * 24 * time.Hour
+
 // saveState persists the daemon state to disk.
 func (d *Daemon) saveState() {
 	if d.state == nil {
 		return
 	}
 	d.state.SetLastPollAt(time.Now())
+
+	// Prune old terminal work items to prevent unbounded state growth.
+	if pruned := d.state.PruneTerminalItems(terminalWorkItemMaxAge); pruned > 0 {
+		d.logger.Info("pruned old terminal work items", "count", pruned)
+	}
+
 	if err := d.state.Save(); err != nil {
 		d.logger.Error("failed to save daemon state", "error", err)
 	}

--- a/internal/daemon/processing.go
+++ b/internal/daemon/processing.go
@@ -646,12 +646,12 @@ func (d *Daemon) resumeDockerPendingItems() {
 // checkDockerHealth probes Docker availability. Returns true if Docker is OK.
 // When Docker is down, it logs a warning once and returns false. When Docker
 // recovers after being down, it logs recovery and returns true.
-func (d *Daemon) checkDockerHealth() bool {
+func (d *Daemon) checkDockerHealth(ctx context.Context) bool {
 	var err error
 	if d.dockerHealthCheck != nil {
-		err = d.dockerHealthCheck()
+		err = d.dockerHealthCheck(ctx)
 	} else {
-		err = defaultDockerHealthCheck()
+		err = defaultDockerHealthCheck(ctx)
 	}
 
 	if err != nil {
@@ -673,8 +673,9 @@ func (d *Daemon) checkDockerHealth() bool {
 }
 
 // defaultDockerHealthCheck runs "docker version" with a 5-second timeout.
-func defaultDockerHealthCheck() error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutDockerHealth)
+// Uses the parent context so the check is cancelled promptly on daemon shutdown.
+func defaultDockerHealthCheck(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, timeoutDockerHealth)
 	defer cancel()
 	return osexec.CommandContext(ctx, "docker", "version").Run()
 }

--- a/internal/daemonstate/state.go
+++ b/internal/daemonstate/state.go
@@ -416,6 +416,32 @@ func StateExists() bool {
 	return len(matches) > 0
 }
 
+// PruneTerminalItems removes completed and failed work items that finished
+// more than maxAge ago. This prevents unbounded growth of the WorkItems map
+// in long-running daemons. Returns the number of items pruned.
+func (s *DaemonState) PruneTerminalItems(maxAge time.Duration) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	pruned := 0
+	for id, item := range s.WorkItems {
+		if !item.IsTerminal() {
+			continue
+		}
+		completedAt := item.CompletedAt
+		if completedAt == nil {
+			// Terminal item without CompletedAt — use UpdatedAt as fallback.
+			completedAt = &item.UpdatedAt
+		}
+		if now.Sub(*completedAt) > maxAge {
+			delete(s.WorkItems, id)
+			pruned++
+		}
+	}
+	return pruned
+}
+
 // ClearState removes all daemon state files from disk.
 // Returns nil if no files exist.
 func ClearState() error {

--- a/internal/daemonstate/state_test.go
+++ b/internal/daemonstate/state_test.go
@@ -889,3 +889,82 @@ func TestDaemonLock_DoubleAcquireFails(t *testing.T) {
 
 	os.Remove(lockPath)
 }
+
+func TestPruneTerminalItems(t *testing.T) {
+	state := NewDaemonState("/test/repo")
+
+	now := time.Now()
+	old := now.Add(-8 * 24 * time.Hour) // 8 days ago
+	recent := now.Add(-1 * time.Hour)   // 1 hour ago
+
+	// Add items in various states
+	state.AddWorkItem(&WorkItem{ID: "active-1", StepData: map[string]any{}})
+	state.AddWorkItem(&WorkItem{ID: "completed-old", StepData: map[string]any{}})
+	state.AddWorkItem(&WorkItem{ID: "completed-recent", StepData: map[string]any{}})
+	state.AddWorkItem(&WorkItem{ID: "failed-old", StepData: map[string]any{}})
+	state.AddWorkItem(&WorkItem{ID: "failed-recent", StepData: map[string]any{}})
+
+	// Mark terminal items
+	state.MarkWorkItemTerminal("completed-old", true)
+	state.MarkWorkItemTerminal("completed-recent", true)
+	state.MarkWorkItemTerminal("failed-old", false)
+	state.MarkWorkItemTerminal("failed-recent", false)
+
+	// Override CompletedAt timestamps
+	state.mu.Lock()
+	state.WorkItems["completed-old"].CompletedAt = &old
+	state.WorkItems["completed-recent"].CompletedAt = &recent
+	state.WorkItems["failed-old"].CompletedAt = &old
+	state.WorkItems["failed-recent"].CompletedAt = &recent
+	state.mu.Unlock()
+
+	pruned := state.PruneTerminalItems(7 * 24 * time.Hour)
+	if pruned != 2 {
+		t.Errorf("expected 2 items pruned, got %d", pruned)
+	}
+
+	// Check that the right items remain
+	if _, ok := state.GetWorkItem("active-1"); !ok {
+		t.Error("active item should not be pruned")
+	}
+	if _, ok := state.GetWorkItem("completed-old"); ok {
+		t.Error("old completed item should be pruned")
+	}
+	if _, ok := state.GetWorkItem("completed-recent"); !ok {
+		t.Error("recent completed item should not be pruned")
+	}
+	if _, ok := state.GetWorkItem("failed-old"); ok {
+		t.Error("old failed item should be pruned")
+	}
+	if _, ok := state.GetWorkItem("failed-recent"); !ok {
+		t.Error("recent failed item should not be pruned")
+	}
+}
+
+func TestPruneTerminalItems_NoCompletedAt(t *testing.T) {
+	state := NewDaemonState("/test/repo")
+
+	old := time.Now().Add(-8 * 24 * time.Hour)
+
+	state.AddWorkItem(&WorkItem{ID: "no-completed-at", StepData: map[string]any{}})
+	state.MarkWorkItemTerminal("no-completed-at", true)
+
+	// Clear CompletedAt and set old UpdatedAt to simulate legacy data
+	state.mu.Lock()
+	state.WorkItems["no-completed-at"].CompletedAt = nil
+	state.WorkItems["no-completed-at"].UpdatedAt = old
+	state.mu.Unlock()
+
+	pruned := state.PruneTerminalItems(7 * 24 * time.Hour)
+	if pruned != 1 {
+		t.Errorf("expected 1 item pruned (using UpdatedAt fallback), got %d", pruned)
+	}
+}
+
+func TestPruneTerminalItems_EmptyState(t *testing.T) {
+	state := NewDaemonState("/test/repo")
+	pruned := state.PruneTerminalItems(7 * 24 * time.Hour)
+	if pruned != 0 {
+		t.Errorf("expected 0 items pruned from empty state, got %d", pruned)
+	}
+}

--- a/internal/issues/asana.go
+++ b/internal/issues/asana.go
@@ -36,6 +36,11 @@ func NewAsanaProvider(cfg AsanaConfigProvider) *AsanaProvider {
 		config: cfg,
 		httpClient: &http.Client{
 			Timeout: asanaHTTPTimeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
 		},
 		apiBase: asanaAPIBase,
 	}

--- a/internal/issues/httpclient.go
+++ b/internal/issues/httpclient.go
@@ -40,7 +40,11 @@ func apiRequest(ctx context.Context, client *http.Client, method, url string, bo
 	if err != nil {
 		return fmt.Errorf("%s API request failed: %w", providerName, err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain remaining body so the underlying TCP connection can be reused.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if forbiddenMsg != "" && resp.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("%s", forbiddenMsg)

--- a/internal/issues/linear.go
+++ b/internal/issues/linear.go
@@ -36,6 +36,11 @@ func NewLinearProvider(cfg LinearConfigProvider) *LinearProvider {
 		config: cfg,
 		httpClient: &http.Client{
 			Timeout: linearHTTPTimeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
 		},
 		apiBase: linearAPIBase,
 	}


### PR DESCRIPTION
## Summary
- **State pruning**: Add `PruneTerminalItems()` to remove completed/failed work items older than 7 days from `DaemonState.WorkItems`, preventing unbounded map and state file growth over weeks of daemon uptime
- **HTTP connection reuse**: Drain response bodies before `Close()` in webhook POST and shared API request helper so pooled TCP connections are returned instead of leaked on error responses
- **HTTP transport limits**: Configure explicit `http.Transport` with `MaxIdleConns`, `MaxIdleConnsPerHost`, and `IdleConnTimeout` for Asana and Linear providers (previously used default transport with no bounds)
- **Context propagation**: Thread parent context through Docker health check so it cancels immediately on daemon shutdown instead of blocking up to 5 seconds on `context.Background()`

## Test plan
- [x] New unit tests for `PruneTerminalItems` (normal, no-CompletedAt fallback, empty state)
- [x] Full test suite passes (`go test -p=1 -count=1 ./...` — all 20 packages green)
- [ ] Verify daemon state file doesn't grow unboundedly over multi-day run

🤖 Generated with [Claude Code](https://claude.com/claude-code)