### PR TITLE
Fix --workflow flag missing from help and root command

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -42,18 +42,21 @@ func init() {
 	rootCmd.Flags().BoolVar(&agentOnce, "once", false, "Run one tick and exit (vs continuous daemon)")
 	rootCmd.Flags().StringVar(&agentRepo, "repo", "", "Repo to poll (owner/repo or filesystem path)")
 	rootCmd.Flags().BoolVar(&agentDaemonMode, "_daemon", false, "Internal: run as detached daemon child")
-	rootCmd.Flags().StringVar(&agentWorkflowFile, "_workflow", "", "Internal: workflow file path passed to daemon child")
-	rootCmd.Flags().MarkHidden("_daemon")   //nolint:errcheck
-	rootCmd.Flags().MarkHidden("_workflow") //nolint:errcheck
-	rootCmd.Flags().MarkHidden("once")      //nolint:errcheck
-	rootCmd.Flags().MarkHidden("repo")      //nolint:errcheck
+	rootCmd.Flags().StringVar(&agentWorkflowFile, "workflow", "", "Path to workflow config file (default: <repo>/.erg/workflow.yaml)")
+	rootCmd.Flags().MarkHidden("_daemon") //nolint:errcheck
+	rootCmd.Flags().MarkHidden("once")    //nolint:errcheck
+	rootCmd.Flags().MarkHidden("repo")    //nolint:errcheck
 }
 
 func runAgent(cmd *cobra.Command, args []string) error {
 	if agentDaemonMode {
 		return runDaemonChild(cmd, args)
 	}
-	// When called as root command without --_daemon, show help
+	// If --workflow was provided, act like `erg start`
+	if agentWorkflowFile != "" {
+		return daemonize(cmd, args)
+	}
+	// When called as root command without actionable flags, show help
 	return cmd.Help()
 }
 
@@ -217,7 +220,7 @@ func buildDaemonArgs(repo string, once bool, workflowFile string) []string {
 		args = append(args, "--once")
 	}
 	if workflowFile != "" {
-		args = append(args, "--_workflow", workflowFile)
+		args = append(args, "--workflow", workflowFile)
 	}
 	return args
 }

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -252,12 +252,12 @@ func TestBuildDaemonArgs_HiddenFlagAppended(t *testing.T) {
 
 func TestBuildDaemonArgs_WithWorkflowFile(t *testing.T) {
 	args := buildDaemonArgs("owner/repo", false, "/custom/workflow.yaml")
-	if !slices.Contains(args, "--_workflow") {
-		t.Errorf("expected '--_workflow' in args: %v", args)
+	if !slices.Contains(args, "--workflow") {
+		t.Errorf("expected '--workflow' in args: %v", args)
 	}
-	idx := slices.Index(args, "--_workflow")
+	idx := slices.Index(args, "--workflow")
 	if idx < 0 || idx+1 >= len(args) {
-		t.Fatalf("--_workflow flag has no value in args: %v", args)
+		t.Fatalf("--workflow flag has no value in args: %v", args)
 	}
 	if args[idx+1] != "/custom/workflow.yaml" {
 		t.Errorf("expected '/custom/workflow.yaml', got %q", args[idx+1])
@@ -265,10 +265,10 @@ func TestBuildDaemonArgs_WithWorkflowFile(t *testing.T) {
 }
 
 func TestBuildDaemonArgs_NoWorkflowFile(t *testing.T) {
-	// When workflowFile is empty, --_workflow should not appear in args.
+	// When workflowFile is empty, --workflow should not appear in args.
 	args := buildDaemonArgs("owner/repo", false, "")
-	if slices.Contains(args, "--_workflow") {
-		t.Errorf("expected no '--_workflow' in args when empty: %v", args)
+	if slices.Contains(args, "--workflow") {
+		t.Errorf("expected no '--workflow' in args when empty: %v", args)
 	}
 }
 
@@ -281,6 +281,16 @@ func TestDaemonFlagIsHidden(t *testing.T) {
 	}
 	if !flag.Hidden {
 		t.Error("expected --_daemon flag to be hidden")
+	}
+}
+
+func TestWorkflowFlagIsVisible(t *testing.T) {
+	flag := rootCmd.Flags().Lookup("workflow")
+	if flag == nil {
+		t.Fatal("expected --workflow flag to exist on root command")
+	}
+	if flag.Hidden {
+		t.Error("expected --workflow flag to be visible")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Renamed the hidden `_workflow` flag to `workflow` on the root command so it appears in `erg --help`
- `erg --workflow <file>` now delegates to the daemonize flow (same as `erg start --workflow <file>`)
- Updated `buildDaemonArgs` to pass `--workflow` (not `--_workflow`) to the re-exec child
- Added `TestWorkflowFlagIsVisible` and updated existing tests

## Test plan
- [x] `go test -p=1 -count=1 ./...` passes
- [x] `erg --help` shows `--workflow` in the Flags section
- [x] `erg --workflow <file>` starts the daemon (no longer errors with "unknown flag")

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)