### PR TITLE
Switch container Ruby/Python installs to mise, add container system prompt

### DIFF
--- a/internal/claude/mock_runner.go
+++ b/internal/claude/mock_runner.go
@@ -53,7 +53,8 @@ type MockRunner struct {
 	// Simulated streaming content for GetMessagesWithStreaming
 	streamingContent string
 
-	stopped bool
+	stopped      bool
+	systemPrompt string
 }
 
 // NewMockRunner creates a mock runner for testing.
@@ -384,7 +385,16 @@ func (m *MockRunner) SetDisableStreamingChunks(disable bool) {
 
 // SetSystemPrompt implements RunnerConfig.
 func (m *MockRunner) SetSystemPrompt(prompt string) {
-	// No-op for mock
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.systemPrompt = prompt
+}
+
+// GetSystemPrompt returns the current system prompt (for test assertions).
+func (m *MockRunner) GetSystemPrompt() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.systemPrompt
 }
 
 // PermissionRequestChan implements RunnerSession.

--- a/internal/container/build.go
+++ b/internal/container/build.go
@@ -77,6 +77,11 @@ func GenerateDockerfile(langs []DetectedLang, version, devBinaryHash string) str
 		}
 	}
 
+	// Install Ruby/Python via mise (if detected)
+	if block := miseInstallBlock(langs); block != "" {
+		b.WriteString(block)
+	}
+
 	// Install the erg binary.
 	if devBinaryHash != "" {
 		// Dev mode: COPY the cross-compiled binary from the build context.
@@ -122,25 +127,11 @@ func languageInstallBlock(l DetectedLang) string {
 			"ENV PATH=\"/usr/local/go/bin:/root/go/bin:${PATH}\"\n",
 			v, goArch())
 	case LangRuby:
-		return fmt.Sprintf(""+
-			"RUN apk add --no-cache autoconf bison openssl-dev yaml-dev readline-dev zlib-dev libffi-dev linux-headers \\\n"+
-			"    && curl -fsSL https://github.com/postmodern/ruby-install/releases/download/v0.9.3/ruby-install-0.9.3.tar.gz | tar -xz \\\n"+
-			"    && cd ruby-install-0.9.3 && make install && cd .. && rm -rf ruby-install-0.9.3 \\\n"+
-			"    && ruby-install --system ruby %s\n",
-			v)
+		// Build dependencies only — mise handles the actual Ruby install.
+		return "RUN apk add --no-cache autoconf bison openssl-dev yaml-dev readline-dev zlib-dev libffi-dev linux-headers\n"
 	case LangPython:
-		// Use pyenv to install the specific Python version requested.
-		// Alpine only ships one system python3 with no version pinning support.
-		return fmt.Sprintf(""+
-			"RUN apk add --no-cache libffi-dev openssl-dev bzip2-dev xz-dev readline-dev sqlite-dev \\\n"+
-			"    && curl -fsSL https://pyenv.run | bash \\\n"+
-			"    && export PYENV_ROOT=\"/root/.pyenv\" \\\n"+
-			"    && export PATH=\"$PYENV_ROOT/bin:$PATH\" \\\n"+
-			"    && pyenv install %s \\\n"+
-			"    && pyenv global %s\n"+
-			"ENV PYENV_ROOT=\"/root/.pyenv\"\n"+
-			"ENV PATH=\"/root/.pyenv/shims:/root/.pyenv/bin:${PATH}\"\n",
-			v, v)
+		// Build dependencies only — mise handles the actual Python install.
+		return "RUN apk add --no-cache libffi-dev openssl-dev bzip2-dev xz-dev readline-dev sqlite-dev\n"
 	case LangRust:
 		return fmt.Sprintf(""+
 			"RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain %s\n"+
@@ -163,6 +154,47 @@ func languageInstallBlock(l DetectedLang) string {
 	default:
 		return ""
 	}
+}
+
+// miseInstallBlock generates Dockerfile instructions to install Ruby and/or Python
+// via mise (https://mise.jdx.dev). Returns empty string if no mise-managed languages
+// are present. Mise provides reproducible, version-pinned installs without the
+// complexity of ruby-install/pyenv.
+func miseInstallBlock(langs []DetectedLang) string {
+	type miseEntry struct {
+		tool    string
+		version string
+	}
+	var entries []miseEntry
+	for _, l := range langs {
+		v := l.Version
+		if v == "" {
+			v = defaultVersions[l.Lang]
+		}
+		switch l.Lang {
+		case LangRuby:
+			entries = append(entries, miseEntry{tool: "ruby", version: v})
+		case LangPython:
+			entries = append(entries, miseEntry{tool: "python", version: v})
+		}
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("RUN curl -fsSL https://mise.jdx.dev/install.sh | sh \\\n")
+	for _, e := range entries {
+		fmt.Fprintf(&b, "    && /root/.local/bin/mise install %s@%s -y \\\n", e.tool, e.version)
+		fmt.Fprintf(&b, "    && /root/.local/bin/mise use -g %s@%s \\\n", e.tool, e.version)
+	}
+	// Trim trailing " \\\n" and add newline
+	s := b.String()
+	s = strings.TrimSuffix(s, " \\\n") + "\n"
+
+	// Add mise shims to PATH so Ruby/Python are available without eval
+	s += "ENV PATH=\"/root/.local/share/mise/shims:/root/.local/bin:${PATH}\"\n"
+	return s
 }
 
 // ImageTag returns a deterministic image tag based on the Dockerfile content.

--- a/internal/container/build_test.go
+++ b/internal/container/build_test.go
@@ -34,8 +34,8 @@ func TestGenerateDockerfile_MultiLanguage(t *testing.T) {
 	if !strings.Contains(df, expected) {
 		t.Errorf("expected %s in Dockerfile", expected)
 	}
-	if !strings.Contains(df, "ruby-install --system ruby 3.3") {
-		t.Error("expected Ruby 3.3 install in Dockerfile")
+	if !strings.Contains(df, "mise install ruby@3.3") {
+		t.Error("expected mise install ruby 3.3 in Dockerfile")
 	}
 	if !strings.Contains(df, "node:20-alpine") {
 		t.Error("expected Node 20 alpine base image")
@@ -117,11 +117,11 @@ func TestGenerateDockerfile_PythonWithVersion(t *testing.T) {
 	df := GenerateDockerfile([]DetectedLang{
 		{Lang: LangPython, Version: "3.11"},
 	}, "0.2.11", "")
-	if !strings.Contains(df, "pyenv install 3.11") {
-		t.Error("expected pyenv install 3.11 in Dockerfile")
+	if !strings.Contains(df, "mise install python@3.11") {
+		t.Error("expected mise install python@3.11 in Dockerfile")
 	}
-	if !strings.Contains(df, "pyenv global 3.11") {
-		t.Error("expected pyenv global 3.11 in Dockerfile")
+	if !strings.Contains(df, "mise use -g python@3.11") {
+		t.Error("expected mise use -g python@3.11 in Dockerfile")
 	}
 }
 
@@ -551,5 +551,65 @@ func TestEnsureImage_ReleaseBuildSkipsCrossCompile(t *testing.T) {
 	_, _, err := EnsureImage(context.Background(), nil, "0.2.11", logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMiseInstallBlock_RubyAndPython(t *testing.T) {
+	block := miseInstallBlock([]DetectedLang{
+		{Lang: LangRuby, Version: "3.3"},
+		{Lang: LangPython, Version: "3.12"},
+	})
+	if !strings.Contains(block, "mise install ruby@3.3") {
+		t.Error("expected mise install ruby@3.3")
+	}
+	if !strings.Contains(block, "mise use -g ruby@3.3") {
+		t.Error("expected mise use -g ruby@3.3")
+	}
+	if !strings.Contains(block, "mise install python@3.12") {
+		t.Error("expected mise install python@3.12")
+	}
+	if !strings.Contains(block, "mise use -g python@3.12") {
+		t.Error("expected mise use -g python@3.12")
+	}
+	if !strings.Contains(block, "mise.jdx.dev/install.sh") {
+		t.Error("expected mise installer URL")
+	}
+}
+
+func TestMiseInstallBlock_NoMiseLanguages(t *testing.T) {
+	block := miseInstallBlock([]DetectedLang{
+		{Lang: LangGo, Version: "1.23"},
+		{Lang: LangNode, Version: "20"},
+	})
+	if block != "" {
+		t.Errorf("expected empty block for non-mise languages, got: %s", block)
+	}
+}
+
+func TestMiseInstallBlock_DefaultVersion(t *testing.T) {
+	block := miseInstallBlock([]DetectedLang{
+		{Lang: LangRuby, Version: ""},
+	})
+	if !strings.Contains(block, "mise install ruby@3.3") {
+		t.Errorf("expected default Ruby version 3.3, got: %s", block)
+	}
+}
+
+func TestMiseInstallBlock_Empty(t *testing.T) {
+	block := miseInstallBlock(nil)
+	if block != "" {
+		t.Errorf("expected empty block for nil langs, got: %s", block)
+	}
+}
+
+func TestGenerateDockerfile_MiseShimsInPath(t *testing.T) {
+	df := GenerateDockerfile([]DetectedLang{
+		{Lang: LangRuby, Version: "3.3"},
+	}, "0.2.11", "")
+	if !strings.Contains(df, "/root/.local/share/mise/shims") {
+		t.Error("expected mise shims in PATH")
+	}
+	if !strings.Contains(df, "/root/.local/bin") {
+		t.Error("expected mise bin dir in PATH")
 	}
 }

--- a/internal/manager/session_manager.go
+++ b/internal/manager/session_manager.go
@@ -22,6 +22,11 @@ import (
 // Compile-time interface satisfaction check.
 var _ SessionManagerConfig = (*config.Config)(nil)
 
+// containerSystemPrompt is prepended to Claude's system prompt when running
+// inside a container. It tells Claude not to run the test suite directly
+// because containers lack the full CI environment (databases, services, etc.).
+const containerSystemPrompt = `You are running inside a container. Do NOT run the full test suite (e.g. "go test ./...", "pytest", "rspec", "npm test") because this container does not have the full CI environment (databases, queues, external services). You may run individual focused tests for files you changed.`
+
 // diffStats holds file change statistics for the header display
 type diffStats struct {
 	FilesChanged int
@@ -378,6 +383,7 @@ func (sm *SessionManager) ConfigureRunnerDefaults(runner claude.RunnerConfig, se
 	// Configure container mode if enabled for this session
 	if sess.Containerized {
 		runner.SetContainerized(true, sm.config.GetContainerImage())
+		runner.SetSystemPrompt(containerSystemPrompt)
 		// Set callback to clear container init state when container is ready
 		sessionID := sess.ID
 		runner.SetOnContainerReady(func() {

--- a/internal/manager/session_manager_test.go
+++ b/internal/manager/session_manager_test.go
@@ -1105,3 +1105,65 @@ func TestConfigureRunnerDefaults_NonDaemonManaged_GetsHostTools(t *testing.T) {
 		t.Error("non-daemon-managed autonomous session SHOULD have host tools enabled")
 	}
 }
+
+func TestConfigureRunnerDefaults_ContainerSystemPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repos: []string{"/test/repo"},
+		Sessions: []config.Session{
+			{
+				ID:            "container-session",
+				RepoPath:      "/test/repo",
+				WorkTree:      "/test/worktree",
+				Branch:        "erg-test",
+				Name:          "repo/session1",
+				Containerized: true,
+			},
+		},
+		AllowedTools:     []string{},
+		RepoAllowedTools: make(map[string][]string),
+	}
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("container-session", false, nil)
+	sess := sm.GetSession("container-session")
+	sm.ConfigureRunnerDefaults(runner, sess)
+
+	prompt := runner.GetSystemPrompt()
+	if prompt == "" {
+		t.Error("expected system prompt to be set for containerized session")
+	}
+	if !strings.Contains(prompt, "container") {
+		t.Error("expected system prompt to mention container")
+	}
+	if !strings.Contains(prompt, "Do NOT run the full test suite") {
+		t.Error("expected system prompt to warn against running full test suite")
+	}
+}
+
+func TestConfigureRunnerDefaults_NonContainerNoSystemPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repos: []string{"/test/repo"},
+		Sessions: []config.Session{
+			{
+				ID:            "normal-session",
+				RepoPath:      "/test/repo",
+				WorkTree:      "/test/worktree",
+				Branch:        "erg-test",
+				Name:          "repo/session1",
+				Containerized: false,
+			},
+		},
+		AllowedTools:     []string{},
+		RepoAllowedTools: make(map[string][]string),
+	}
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("normal-session", false, nil)
+	sess := sm.GetSession("normal-session")
+	sm.ConfigureRunnerDefaults(runner, sess)
+
+	prompt := runner.GetSystemPrompt()
+	if prompt != "" {
+		t.Errorf("expected no system prompt for non-containerized session, got %q", prompt)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace ruby-install and pyenv with [mise](https://mise.jdx.dev) for reproducible, version-pinned Ruby and Python installs in containers
- Add a system prompt for containerized sessions telling Claude not to run the full test suite (containers lack full CI environment)
- Update MockRunner to store system prompt for test assertions

## Test plan
- [x] Existing container build tests updated for mise (MultiLanguage, PythonWithVersion)
- [x] New unit tests for `miseInstallBlock` (Ruby+Python, no-mise languages, default version, empty)
- [x] New test for mise shims in PATH
- [x] New tests for container system prompt (set for containerized, absent for non-containerized)
- [x] `go test -p=1 -count=1 ./internal/container/... ./internal/manager/... ./internal/claude/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)