### PR TITLE
Fix plan feedback detection and hide Asana comment markers

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -3857,7 +3857,7 @@ func TestErgGitHubMarker(t *testing.T) {
 
 func TestErgProviderMarker(t *testing.T) {
 	marker := ergProviderMarker("notify")
-	if marker != "[erg:step=notify]" {
+	if marker != "<!-- erg:step=notify -->" {
 		t.Errorf("unexpected marker: %q", marker)
 	}
 }
@@ -4085,7 +4085,7 @@ func TestCommentViaProvider_IdempotentCreatesNew(t *testing.T) {
 		t.Errorf("expected 0 updates, got %d", len(provider.updates))
 	}
 	// Body should include the provider marker
-	if !strings.Contains(provider.comments[0].body, "[erg:step=open_pr]") {
+	if !strings.Contains(provider.comments[0].body, "<!-- erg:step=open_pr -->") {
 		t.Errorf("expected marker in comment body, got: %q", provider.comments[0].body)
 	}
 }
@@ -4099,7 +4099,7 @@ func TestCommentViaProvider_IdempotentUpdatesExisting(t *testing.T) {
 	provider := &mockIdempotentCommentProvider{
 		src: issues.SourceAsana,
 		existingComments: []issues.IssueComment{
-			{ID: "story-1", Body: "Old message [erg:step=open_pr]"},
+			{ID: "story-1", Body: "Old message <!-- erg:step=open_pr -->"},
 		},
 	}
 	registry := issues.NewProviderRegistry(provider)
@@ -4137,11 +4137,61 @@ func TestCommentViaProvider_IdempotentUpdatesExisting(t *testing.T) {
 	if provider.updates[0].commentID != "story-1" {
 		t.Errorf("expected commentID 'story-1', got %q", provider.updates[0].commentID)
 	}
-	if !strings.Contains(provider.updates[0].body, "[erg:step=open_pr]") {
+	if !strings.Contains(provider.updates[0].body, "<!-- erg:step=open_pr -->") {
 		t.Errorf("expected marker in updated body, got: %q", provider.updates[0].body)
 	}
 	if !strings.Contains(provider.updates[0].body, "Updated message!") {
 		t.Errorf("expected updated content in body, got: %q", provider.updates[0].body)
+	}
+}
+
+func TestCommentViaProvider_IdempotentUpdatesLegacyMarker(t *testing.T) {
+	// When an existing comment uses the old [erg:step=…] marker format,
+	// the idempotent update should still find and update it.
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	d.repoFilter = "/test/repo"
+
+	provider := &mockIdempotentCommentProvider{
+		src: issues.SourceAsana,
+		existingComments: []issues.IssueComment{
+			{ID: "story-legacy", Body: "Old plan\n[erg:step=open_pr]"},
+		},
+	}
+	registry := issues.NewProviderRegistry(provider)
+	d.issueRegistry = registry
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "asana", ID: "task-abc"},
+		SessionID: "sess-1",
+	})
+
+	action := &asanaCommentAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"body": "New plan"})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+		Step:       "open_pr",
+	}
+
+	result := action.Execute(context.Background(), ac)
+	if !result.Success {
+		t.Errorf("expected success, got error: %v", result.Error)
+	}
+
+	// Should have updated the legacy comment, not created a new one.
+	if len(provider.updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(provider.updates))
+	}
+	if provider.updates[0].commentID != "story-legacy" {
+		t.Errorf("expected commentID 'story-legacy', got %q", provider.updates[0].commentID)
+	}
+	if len(provider.comments) != 0 {
+		t.Errorf("expected 0 new comments, got %d", len(provider.comments))
 	}
 }
 

--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -13,13 +13,20 @@ import (
 	"github.com/zhubert/erg/internal/workflow"
 )
 
-// isErgSystemComment reports whether a comment body was posted by the erg daemon
+// isErgSystemComment reports whether a comment was posted by the erg daemon
 // itself (e.g. guidance, idempotency-marked actions). Such comments must be
 // excluded from human-reply checks so they never accidentally trigger approvals.
-func isErgSystemComment(body string) bool {
-	// Provider-marker format used for Asana/Linear comments: [erg:step=…]
-	// HTML-comment format used for GitHub: <!-- erg:step=… -->
-	return strings.Contains(body, "[erg:step=") || strings.Contains(body, "<!-- erg:step=")
+func isErgSystemComment(c issues.IssueComment) bool {
+	// Check plain text body for legacy [erg:step=…] markers (Linear)
+	// and GitHub HTML comments (<!-- erg:step=… -->).
+	if strings.Contains(c.Body, "[erg:step=") || strings.Contains(c.Body, "<!-- erg:step=") {
+		return true
+	}
+	// Check HTMLBody for Asana HTML comment markers that are stripped from plain text.
+	if c.HTMLBody != "" && strings.Contains(c.HTMLBody, "<!-- erg:step=") {
+		return true
+	}
+	return false
 }
 
 // eventChecker implements workflow.EventChecker for the daemon.
@@ -447,7 +454,7 @@ func (c *eventChecker) checkGateApproved(ctx context.Context, params *workflow.P
 
 		for _, comment := range comments {
 			// Skip comments posted by the erg daemon itself (e.g. guidance, markers).
-			if isErgSystemComment(comment.Body) {
+			if isErgSystemComment(comment) {
 				continue
 			}
 			// Only consider comments posted after the gate step was entered.
@@ -581,7 +588,7 @@ func (c *eventChecker) checkPlanUserReplied(ctx context.Context, params *workflo
 
 	for _, comment := range comments {
 		// Skip comments posted by the erg daemon itself (e.g. guidance, markers).
-		if isErgSystemComment(comment.Body) {
+		if isErgSystemComment(comment) {
 			continue
 		}
 		// Only consider comments posted after the step was entered.

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -3345,17 +3345,28 @@ func TestCheckEvent_LinearInState_Dispatches(t *testing.T) {
 // --- isErgSystemComment / guidance self-trigger prevention ---
 
 func TestIsErgSystemComment_AsanaMarker(t *testing.T) {
-	// Asana/Linear provider marker format
-	body := "The plan above is ready for your review.\n[erg:step=await_plan_feedback]"
-	if !isErgSystemComment(body) {
-		t.Error("expected Asana marker to be detected as system comment")
+	// Legacy Asana/Linear provider marker in plain text body
+	c := issues.IssueComment{Body: "The plan above is ready for your review.\n[erg:step=await_plan_feedback]"}
+	if !isErgSystemComment(c) {
+		t.Error("expected legacy Asana marker to be detected as system comment")
+	}
+}
+
+func TestIsErgSystemComment_AsanaHTMLMarker(t *testing.T) {
+	// Asana HTML comment marker: invisible in plain text, present in HTMLBody
+	c := issues.IssueComment{
+		Body:     "The plan above is ready for your review.",
+		HTMLBody: "<body>The plan above is ready for your review.</body><!-- erg:step=await_plan_feedback -->",
+	}
+	if !isErgSystemComment(c) {
+		t.Error("expected Asana HTML marker to be detected as system comment")
 	}
 }
 
 func TestIsErgSystemComment_GitHubMarker(t *testing.T) {
 	// GitHub HTML comment marker format
-	body := "Please review and approve the PR.\n<!-- erg:step=await_review -->"
-	if !isErgSystemComment(body) {
+	c := issues.IssueComment{Body: "Please review and approve the PR.\n<!-- erg:step=await_review -->"}
+	if !isErgSystemComment(c) {
 		t.Error("expected GitHub marker to be detected as system comment")
 	}
 }
@@ -3369,7 +3380,7 @@ func TestIsErgSystemComment_HumanComment(t *testing.T) {
 		"approved",
 	}
 	for _, body := range humanComments {
-		if isErgSystemComment(body) {
+		if isErgSystemComment(issues.IssueComment{Body: body}) {
 			t.Errorf("human comment %q incorrectly flagged as system comment", body)
 		}
 	}
@@ -3383,13 +3394,18 @@ func TestCheckPlanUserReplied_GuidanceCommentNotSelfApproved(t *testing.T) {
 
 	// Simulate the guidance comment that postWaitGuidance would post.
 	// It contains words like "approved" and "proceed" which match typical patterns.
-	guidanceBody := `The plan above is ready for your review. Reply with your feedback to request changes, or reply with an approval (e.g. "LGTM", "looks good", "approved") to proceed.
-[erg:step=await_plan_feedback]`
+	// For Asana, the marker is in HTMLBody (invisible in rendered comment).
+	guidanceText := `The plan above is ready for your review. Reply with your feedback to request changes, or reply with an approval (e.g. "LGTM", "looks good", "approved") to proceed.`
 
 	provider := &mockGateProvider{
 		src: issues.SourceAsana,
 		comments: []issues.IssueComment{
-			{Author: "erg-bot", Body: guidanceBody, CreatedAt: now.Add(time.Minute)},
+			{
+				Author:   "erg-bot",
+				Body:     guidanceText,
+				HTMLBody: "<body>" + guidanceText + "</body><!-- erg:step=await_plan_feedback -->",
+				CreatedAt: now.Add(time.Minute),
+			},
 		},
 	}
 	d := testDaemonWithGateProvider(cfg, provider)
@@ -3428,12 +3444,18 @@ func TestCheckGateApproved_GuidanceCommentNotSelfApproved(t *testing.T) {
 	now := time.Now()
 
 	// A guidance comment for comment_match gate includes the pattern string.
-	guidanceBody := "Reply to this issue with a comment matching: `(?i)LGTM`\n[erg:step=await_gate]"
+	// For Asana, the marker is in HTMLBody (invisible in rendered comment).
+	guidanceText := "Reply to this issue with a comment matching: `(?i)LGTM`"
 
 	provider := &mockGateProvider{
 		src: issues.SourceAsana,
 		comments: []issues.IssueComment{
-			{Author: "erg-bot", Body: guidanceBody, CreatedAt: now.Add(time.Minute)},
+			{
+				Author:   "erg-bot",
+				Body:     guidanceText,
+				HTMLBody: "<body>" + guidanceText + "</body><!-- erg:step=await_gate -->",
+				CreatedAt: now.Add(time.Minute),
+			},
 		},
 	}
 	d := testDaemonWithGateProvider(cfg, provider)

--- a/internal/daemon/github_ops.go
+++ b/internal/daemon/github_ops.go
@@ -236,10 +236,17 @@ func ergGitHubMarker(step string) string {
 }
 
 // ergProviderMarker returns the idempotency marker for Asana/Linear comments.
-// Uses a plain-text bracket format since Asana renders stories as plain text
-// and the marker must be visible to be searchable.
+// Uses HTML comment format (<!-- erg:step=… -->) which is hidden in rendered
+// output. For Asana, the marker is preserved in the html_text field. For
+// Linear, it is invisible in rendered markdown.
 func ergProviderMarker(step string) string {
-	return fmt.Sprintf("[erg:step=%s]", step)
+	return fmt.Sprintf("<!-- erg:step=%s -->", step)
+}
+
+// containsMarker checks if a comment contains the given marker string in either
+// its plain text body or its HTML body.
+func containsMarker(c issues.IssueComment, marker string) bool {
+	return strings.Contains(c.Body, marker) || (c.HTMLBody != "" && strings.Contains(c.HTMLBody, marker))
 }
 
 // commentOnIssue posts a comment on the GitHub issue for a work item.
@@ -401,6 +408,7 @@ func (d *Daemon) commentViaProvider(ctx context.Context, item daemonstate.WorkIt
 
 	if step != "" {
 		marker := ergProviderMarker(step)
+		legacyMarker := fmt.Sprintf("[erg:step=%s]", step) // backward compat with old plain-text markers
 		markedBody := body + "\n" + marker
 
 		// Attempt idempotent upsert if the provider supports it.
@@ -409,7 +417,7 @@ func (d *Daemon) commentViaProvider(ctx context.Context, item daemonstate.WorkIt
 				existing, listErr := gc.GetIssueComments(commentCtx, repoPath, item.IssueRef.ID)
 				if listErr == nil {
 					for _, c := range existing {
-						if strings.Contains(c.Body, marker) {
+						if containsMarker(c, marker) || containsMarker(c, legacyMarker) {
 							return cu.UpdateComment(commentCtx, repoPath, item.IssueRef.ID, c.ID, markedBody)
 						}
 					}

--- a/internal/issues/asana.go
+++ b/internal/issues/asana.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
 	"regexp"
@@ -444,6 +445,7 @@ type asanaStory struct {
 	GID       string `json:"gid"`
 	Type      string `json:"type"`
 	Text      string `json:"text"`
+	HTMLText  string `json:"html_text"`
 	CreatedAt string `json:"created_at"`
 	CreatedBy struct {
 		Name string `json:"name"`
@@ -463,7 +465,7 @@ func (p *AsanaProvider) GetIssueComments(ctx context.Context, repoPath string, i
 		return nil, fmt.Errorf("ASANA_PAT environment variable not set")
 	}
 
-	url := fmt.Sprintf("%s/tasks/%s/stories?opt_fields=gid,type,text,created_at,created_by.name", p.apiBase, issueID)
+	url := fmt.Sprintf("%s/tasks/%s/stories?opt_fields=gid,type,text,html_text,created_at,created_by.name", p.apiBase, issueID)
 
 	var storiesResp asanaStoriesResponse
 	if err := apiRequest(ctx, p.httpClient, http.MethodGet, url, nil,
@@ -479,11 +481,12 @@ func (p *AsanaProvider) GetIssueComments(ctx context.Context, repoPath string, i
 		if story.Text == "" {
 			continue
 		}
-		createdAt, _ := time.Parse(time.RFC3339, story.CreatedAt)
+		createdAt, _ := time.Parse(time.RFC3339Nano, story.CreatedAt)
 		comments = append(comments, IssueComment{
 			ID:        story.GID,
 			Author:    story.CreatedBy.Name,
 			Body:      story.Text,
+			HTMLBody:  story.HTMLText,
 			CreatedAt: createdAt,
 		})
 	}
@@ -602,7 +605,35 @@ func (p *AsanaProvider) MoveToSection(ctx context.Context, repoPath string, issu
 		"Bearer "+pat, http.StatusOK, "", "Asana", nil)
 }
 
+// plainTextToAsanaHTML converts plain text to Asana-compatible HTML.
+// Asana's rich text API expects content wrapped in <body> tags.
+// HTML comments (<!-- ... -->) in the input are preserved as-is so they
+// can serve as hidden markers in the rendered comment.
+func plainTextToAsanaHTML(text string) string {
+	// Extract HTML comments before escaping, then re-insert them.
+	var htmlComments []string
+	stripped := htmlCommentRe.ReplaceAllStringFunc(text, func(match string) string {
+		htmlComments = append(htmlComments, match)
+		return "" // remove from plain text
+	})
+
+	stripped = strings.TrimRight(stripped, "\n ")
+	escaped := html.EscapeString(stripped)
+	escaped = strings.ReplaceAll(escaped, "\n", "<br>")
+
+	result := "<body>" + escaped + "</body>"
+	// Append HTML comments after the body — they are invisible to users
+	// but preserved in Asana's html_text field for marker detection.
+	for _, c := range htmlComments {
+		result += c
+	}
+	return result
+}
+
+var htmlCommentRe = regexp.MustCompile(`<!--[\s\S]*?-->`)
+
 // Comment adds a comment (story) to an Asana task.
+// Uses html_text to support hidden HTML comment markers.
 // Implements ProviderActions.
 func (p *AsanaProvider) Comment(ctx context.Context, repoPath string, issueID string, body string) error {
 	pat := os.Getenv(asanaPATEnvVar)
@@ -611,17 +642,19 @@ func (p *AsanaProvider) Comment(ctx context.Context, repoPath string, issueID st
 	}
 
 	storiesURL := fmt.Sprintf("%s/tasks/%s/stories", p.apiBase, issueID)
-	textJSON, err := json.Marshal(body)
+	htmlBody := plainTextToAsanaHTML(body)
+	htmlJSON, err := json.Marshal(htmlBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal comment body: %w", err)
 	}
-	reqBody := fmt.Sprintf(`{"data":{"text":%s}}`, textJSON)
+	reqBody := fmt.Sprintf(`{"data":{"html_text":%s}}`, htmlJSON)
 
 	return apiRequest(ctx, p.httpClient, http.MethodPost, storiesURL, strings.NewReader(reqBody),
 		"Bearer "+pat, http.StatusCreated, "", "Asana", nil)
 }
 
 // UpdateComment updates an existing Asana story (comment) by its GID.
+// Uses html_text to support hidden HTML comment markers.
 // Implements ProviderCommentUpdater.
 func (p *AsanaProvider) UpdateComment(ctx context.Context, repoPath string, issueID string, commentID string, body string) error {
 	pat := os.Getenv(asanaPATEnvVar)
@@ -630,11 +663,12 @@ func (p *AsanaProvider) UpdateComment(ctx context.Context, repoPath string, issu
 	}
 
 	storyURL := fmt.Sprintf("%s/stories/%s", p.apiBase, commentID)
-	textJSON, err := json.Marshal(body)
+	htmlBody := plainTextToAsanaHTML(body)
+	htmlJSON, err := json.Marshal(htmlBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal comment body: %w", err)
 	}
-	reqBody := fmt.Sprintf(`{"data":{"text":%s}}`, textJSON)
+	reqBody := fmt.Sprintf(`{"data":{"html_text":%s}}`, htmlJSON)
 
 	return apiRequest(ctx, p.httpClient, http.MethodPut, storyURL, strings.NewReader(reqBody),
 		"Bearer "+pat, http.StatusOK, "", "Asana", nil)

--- a/internal/issues/asana_test.go
+++ b/internal/issues/asana_test.go
@@ -13,6 +13,44 @@ import (
 	"github.com/zhubert/erg/internal/config"
 )
 
+func TestPlainTextToAsanaHTML_Basic(t *testing.T) {
+	result := plainTextToAsanaHTML("Hello world")
+	if result != "<body>Hello world</body>" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestPlainTextToAsanaHTML_Newlines(t *testing.T) {
+	result := plainTextToAsanaHTML("Line 1\nLine 2")
+	if result != "<body>Line 1<br>Line 2</body>" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestPlainTextToAsanaHTML_HTMLEscaping(t *testing.T) {
+	result := plainTextToAsanaHTML("a < b & c > d")
+	if result != "<body>a &lt; b &amp; c &gt; d</body>" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestPlainTextToAsanaHTML_PreservesHTMLComments(t *testing.T) {
+	input := "Plan looks good\n<!-- erg:step=await_plan_feedback -->"
+	result := plainTextToAsanaHTML(input)
+	if !strings.Contains(result, "<!-- erg:step=await_plan_feedback -->") {
+		t.Errorf("HTML comment marker should be preserved, got: %q", result)
+	}
+	if strings.Contains(result, "&lt;!--") {
+		t.Errorf("HTML comment should not be escaped, got: %q", result)
+	}
+	// The visible text should not contain the marker
+	if strings.Contains(result, "<body>") && strings.Contains(result, "Plan looks good") {
+		// good
+	} else {
+		t.Errorf("expected body with visible text, got: %q", result)
+	}
+}
+
 func TestAsanaProvider_Name(t *testing.T) {
 	p := NewAsanaProvider(nil)
 	if p.Name() != "Asana Tasks" {
@@ -960,6 +998,46 @@ func TestAsanaProvider_GetIssueComments_ReturnsComments(t *testing.T) {
 	}
 }
 
+func TestAsanaProvider_GetIssueComments_MillisecondTimestamps(t *testing.T) {
+	// Asana returns timestamps with milliseconds (e.g. "2024-01-15T10:00:00.147Z").
+	// These must parse correctly; a zero CreatedAt would cause the event checker
+	// to silently skip all comments.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{
+					"gid":        "story-1",
+					"type":       "comment",
+					"text":       "Looks good!",
+					"created_at": "2024-01-15T10:30:00.147Z",
+					"created_by": map[string]any{"name": "alice"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	origPAT := os.Getenv(asanaPATEnvVar)
+	defer os.Setenv(asanaPATEnvVar, origPAT)
+	os.Setenv(asanaPATEnvVar, "test-pat")
+
+	p := NewAsanaProviderWithClient(nil, server.Client(), server.URL)
+	comments, err := p.GetIssueComments(context.Background(), "/repo", "task-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].CreatedAt.IsZero() {
+		t.Fatal("expected non-zero CreatedAt for millisecond timestamp")
+	}
+	if comments[0].CreatedAt.Year() != 2024 {
+		t.Errorf("expected year 2024, got %d", comments[0].CreatedAt.Year())
+	}
+}
+
 func TestAsanaProvider_GetIssueComments_EmptyBodyExcluded(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1399,7 +1477,8 @@ func TestAsanaProvider_GetIssueComments_IncludesGID(t *testing.T) {
 				{
 					"gid":        "story-gid-1",
 					"type":       "comment",
-					"text":       "First comment [erg:step=notify]",
+					"text":       "First comment",
+					"html_text":  "<body>First comment</body><!-- erg:step=notify -->",
 					"created_at": "2024-01-01T10:00:00Z",
 					"created_by": map[string]any{"name": "Bot"},
 				},
@@ -1430,8 +1509,12 @@ func TestAsanaProvider_GetIssueComments_IncludesGID(t *testing.T) {
 	if comments[0].ID != "story-gid-1" {
 		t.Errorf("expected ID 'story-gid-1', got %q", comments[0].ID)
 	}
-	if !strings.Contains(comments[0].Body, "[erg:step=notify]") {
-		t.Errorf("expected marker in comment body, got %q", comments[0].Body)
+	// Marker should be in HTMLBody, not in plain text Body
+	if strings.Contains(comments[0].Body, "erg:step=") {
+		t.Errorf("marker should not be in plain text body, got %q", comments[0].Body)
+	}
+	if !strings.Contains(comments[0].HTMLBody, "<!-- erg:step=notify -->") {
+		t.Errorf("expected HTML marker in HTMLBody, got %q", comments[0].HTMLBody)
 	}
 	if comments[1].ID != "story-gid-2" {
 		t.Errorf("expected ID 'story-gid-2', got %q", comments[1].ID)
@@ -1460,9 +1543,12 @@ func TestAsanaProvider_UpdateComment_Success(t *testing.T) {
 	os.Setenv(asanaPATEnvVar, "test-pat")
 
 	p := NewAsanaProviderWithClient(nil, server.Client(), server.URL)
-	err := p.UpdateComment(context.Background(), "/repo", "task-123", "story-gid-1", "Updated body [erg:step=notify]")
+	err := p.UpdateComment(context.Background(), "/repo", "task-123", "story-gid-1", "Updated body\n<!-- erg:step=notify -->")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedBody, "html_text") {
+		t.Errorf("expected html_text in request body, got: %s", capturedBody)
 	}
 	if !strings.Contains(capturedBody, "Updated body") {
 		t.Errorf("expected updated body in request, got: %s", capturedBody)

--- a/internal/issues/linear.go
+++ b/internal/issues/linear.go
@@ -339,7 +339,7 @@ func (p *LinearProvider) GetIssueComments(ctx context.Context, repoPath string, 
 		if n.Body == "" {
 			continue
 		}
-		createdAt, _ := time.Parse(time.RFC3339, n.CreatedAt)
+		createdAt, _ := time.Parse(time.RFC3339Nano, n.CreatedAt)
 		comments = append(comments, IssueComment{
 			ID:        n.ID,
 			Author:    n.User.Name,

--- a/internal/issues/linear_test.go
+++ b/internal/issues/linear_test.go
@@ -830,6 +830,49 @@ func TestLinearProvider_GetIssueComments_ReturnsComments(t *testing.T) {
 	}
 }
 
+func TestLinearProvider_GetIssueComments_MillisecondTimestamps(t *testing.T) {
+	// Linear returns timestamps with milliseconds (e.g. "2024-01-15T10:00:00.147Z").
+	// These must parse correctly; a zero CreatedAt would cause the event checker
+	// to silently skip all comments.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := linearIssueCommentsResponse{}
+		resp.Data.Issue.Comments.Nodes = []struct {
+			ID        string `json:"id"`
+			Body      string `json:"body"`
+			CreatedAt string `json:"createdAt"`
+			User      struct {
+				Name string `json:"name"`
+			} `json:"user"`
+		}{
+			{ID: "cmt-1", Body: "Looks good!", CreatedAt: "2024-01-15T10:30:00.147Z", User: struct {
+				Name string `json:"name"`
+			}{Name: "alice"}},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test")
+
+	p := NewLinearProviderWithClient(nil, server.Client(), server.URL)
+	comments, err := p.GetIssueComments(context.Background(), "/repo", "ENG-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].CreatedAt.IsZero() {
+		t.Fatal("expected non-zero CreatedAt for millisecond timestamp")
+	}
+	if comments[0].CreatedAt.Year() != 2024 {
+		t.Errorf("expected year 2024, got %d", comments[0].CreatedAt.Year())
+	}
+}
+
 func TestLinearProvider_GetIssueComments_EmptyBodyExcluded(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -118,7 +118,8 @@ func (r *ProviderRegistry) AllProviders() []Provider {
 type IssueComment struct {
 	ID        string    // Provider-specific comment identifier (for updates; empty if not supported)
 	Author    string    // Username or display name
-	Body      string    // Comment text
+	Body      string    // Comment text (plain text)
+	HTMLBody  string    // HTML version of the comment (may contain hidden markers; empty if not available)
 	CreatedAt time.Time // When the comment was posted
 }
 


### PR DESCRIPTION
## Summary

- **Fix timestamp parsing**: Asana/Linear return timestamps with milliseconds (e.g. `2024-01-15T10:30:00.147Z`) which `time.RFC3339` silently fails to parse, returning zero time. This caused `checkPlanUserReplied` to skip all comments — the daemon sat forever in `await_plan_feedback`. Fixed by using `time.RFC3339Nano`.
- **Hide Asana markers**: The `[erg:step=...]` idempotency marker was visible in Asana comments. Now uses Asana's `html_text` API field with `<!-- erg:step=... -->` HTML comments that are invisible in rendered output. Added backward compat for old plain-text markers.

## Test plan

- [x] New tests for millisecond timestamp parsing (Asana + Linear)
- [x] New tests for `plainTextToAsanaHTML` marker preservation
- [x] New test for `isErgSystemComment` with Asana HTML markers
- [x] New test for backward-compat legacy marker detection in idempotent updates
- [x] Updated existing marker/guidance tests for new format
- [x] Full test suite passes
- [ ] Manual verification that Asana preserves `<!-- ... -->` in `html_text` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)