### PR TITLE
docs: add brew services info to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ erg start --repo owner/repo
 
 Label a GitHub issue `queued` and erg picks it up — coding, PR, review feedback, CI, and merge are handled automatically. See the [docs](https://zhubert.com/erg/) for full configuration options including Asana and Linear as work sources.
 
+## Run as a Service (macOS)
+
+If you installed via Homebrew, run erg as a persistent background service that starts on login:
+
+```bash
+brew services start erg
+```
+
+See the [docs](https://zhubert.com/erg/) for daemon config and the full list of `brew services` commands.
+
 ## Build from Source
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -2052,6 +2052,10 @@
               <td>Stop erg and remove the login item</td>
             </tr>
             <tr>
+              <td><code>brew services restart erg</code></td>
+              <td>Restart erg (e.g. after updating config)</td>
+            </tr>
+            <tr>
               <td><code>brew services info erg</code></td>
               <td>Show service status</td>
             </tr>


### PR DESCRIPTION
## Summary
Documents how to run erg as a persistent background service via Homebrew on macOS.

## Changes
- Add "Run as a Service (macOS)" section to README with `brew services start erg` quick-start
- Add `brew services restart erg` row to the services command table in docs/index.html

## Test plan
- Verify README renders correctly on GitHub
- Verify docs site table displays the new restart row properly

Fixes #283