### PR TITLE
Fix stream parser failing on array-typed tool_use_result

### DIFF
--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -812,6 +812,35 @@ func TestToolUseResultField_UnmarshalJSON_ObjectWithFile(t *testing.T) {
 	}
 }
 
+func TestToolUseResultField_UnmarshalJSON_Array(t *testing.T) {
+	// Test unmarshaling an array of content blocks (Claude CLI sometimes sends this)
+	jsonStr := `[{"type":"text","text":"{\"id\":3,\"success\":true}"}]`
+	var field toolUseResultField
+	if err := json.Unmarshal([]byte(jsonStr), &field); err != nil {
+		t.Fatalf("Failed to unmarshal array: %v", err)
+	}
+	if field.StringValue != "" {
+		t.Errorf("Expected StringValue to be empty, got %q", field.StringValue)
+	}
+	if field.Data == nil {
+		t.Fatal("Expected Data to be populated from first array element")
+	}
+	if field.Data.Type != "text" {
+		t.Errorf("Expected Data.Type 'text', got %q", field.Data.Type)
+	}
+}
+
+func TestToolUseResultField_UnmarshalJSON_EmptyArray(t *testing.T) {
+	jsonStr := `[]`
+	var field toolUseResultField
+	if err := json.Unmarshal([]byte(jsonStr), &field); err != nil {
+		t.Fatalf("Failed to unmarshal empty array: %v", err)
+	}
+	if field.Data != nil {
+		t.Errorf("Expected Data to be nil for empty array, got %+v", field.Data)
+	}
+}
+
 func TestParseStreamMessage_Result(t *testing.T) {
 	log := testLogger()
 	msg := `{"type":"result","subtype":"success","result":"Operation completed"}`

--- a/internal/claude/parsing.go
+++ b/internal/claude/parsing.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 )
@@ -89,7 +90,7 @@ type toolUseResultField struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler for toolUseResultField.
-// It handles both string values and structured objects.
+// It handles string values, structured objects, and arrays of content blocks.
 func (f *toolUseResultField) UnmarshalJSON(data []byte) error {
 	// First, try to unmarshal as a string
 	var s string
@@ -98,12 +99,22 @@ func (f *toolUseResultField) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Not a string, try as structured object
+	// Try as structured object
 	var obj toolUseResultData
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return err
+	if err := json.Unmarshal(data, &obj); err == nil {
+		f.Data = &obj
+		return nil
 	}
-	f.Data = &obj
+
+	// Try as array of content blocks (e.g., [{"type":"text","text":"..."}])
+	var arr []toolUseResultData
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return fmt.Errorf("tool_use_result: cannot unmarshal as string, object, or array: %w", err)
+	}
+	// Use the first element if available
+	if len(arr) > 0 {
+		f.Data = &arr[0]
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Claude CLI sometimes sends `tool_use_result` as an array of content blocks (e.g., `[{"type":"text","text":"..."}]`) rather than a string or object
- `toolUseResultField.UnmarshalJSON` now handles all three formats: string, object, and array
- Adds tests for array and empty array cases

## Test plan
- [x] New unit tests for array and empty array unmarshaling
- [x] Existing unmarshal tests still pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)