### PR TITLE
feat(daemon): restrict plan approvals to repository collaborators only

### DIFF
--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -457,6 +457,18 @@ func (c *eventChecker) checkGateApproved(ctx context.Context, params *workflow.P
 				continue
 			}
 			if re.MatchString(comment.Body) {
+				// For GitHub issues, only collaborators may approve via comment.
+				if source == "github" {
+					isCollab, err := d.gitService.CheckUserIsCollaborator(pollCtx, repoPath, comment.Author)
+					if err != nil {
+						log.Warn("failed to check collaborator status, skipping comment", "author", comment.Author, "error", err)
+						continue
+					}
+					if !isCollab {
+						log.Info("ignoring gate approval from non-collaborator", "author", comment.Author)
+						continue
+					}
+				}
 				log.Info("gate comment pattern matched", "pattern", pattern, "author", comment.Author)
 				return true, map[string]any{"gate_approved": true, "gate_trigger": "comment_match", "gate_comment_author": comment.Author}, nil
 			}
@@ -593,6 +605,17 @@ func (c *eventChecker) checkPlanUserReplied(ctx context.Context, params *workflo
 
 		// Found a new comment — check if it's an approval.
 		approved := approvalRe != nil && approvalRe.MatchString(comment.Body)
+		// For GitHub issues, only collaborators may approve plans.
+		if approved && workItem.IssueRef.Source == "github" {
+			isCollab, err := d.gitService.CheckUserIsCollaborator(pollCtx, repoPath, comment.Author)
+			if err != nil {
+				log.Warn("failed to check collaborator status, denying plan approval", "author", comment.Author, "error", err)
+				approved = false
+			} else if !isCollab {
+				log.Info("plan approval from non-collaborator, treating as feedback only", "author", comment.Author)
+				approved = false
+			}
+		}
 		log.Info("user replied to plan", "author", comment.Author, "approved", approved)
 		return true, map[string]any{
 			"plan_approved":        approved,

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -1906,6 +1906,100 @@ func TestCheckGateApproved_UnknownTrigger(t *testing.T) {
 	}
 }
 
+func TestCheckGateApproved_CommentMatch_NonCollaboratorIgnored(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Matching comment from a non-collaborator.
+	commentsJSON := []byte(`{"comments":[{"author":{"login":"outsider"},"body":"/approve please","createdAt":"2020-01-01T10:05:00Z"}]}`)
+	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+		Stdout: commentsJSON,
+	})
+	// Collaborator check for "outsider" returns 404 (not a collaborator).
+	mockExec.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/collaborators/outsider"}, exec.MockResponse{
+		Err: fmt.Errorf("HTTP 404: Not Found"),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "42"},
+		SessionID:   "sess-1",
+		CurrentStep: "await_approval",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{"trigger": "comment_match", "comment_pattern": `^/approve`})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+	view.StepEnteredAt = time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	fired, _, err := checker.checkGateApproved(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fired {
+		t.Error("expected fired=false when matching comment is from a non-collaborator")
+	}
+}
+
+func TestCheckGateApproved_CommentMatch_CollaboratorApproves(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Matching comment from a collaborator.
+	commentsJSON := []byte(`{"comments":[{"author":{"login":"contributor"},"body":"/approve looks good","createdAt":"2020-01-01T10:05:00Z"}]}`)
+	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+		Stdout: commentsJSON,
+	})
+	// Collaborator check for "contributor" succeeds (HTTP 204 → no error).
+	mockExec.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/collaborators/contributor"}, exec.MockResponse{
+		Stdout: []byte(``),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "42"},
+		SessionID:   "sess-1",
+		CurrentStep: "await_approval",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{"trigger": "comment_match", "comment_pattern": `^/approve`})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+	view.StepEnteredAt = time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	fired, data, err := checker.checkGateApproved(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fired {
+		t.Error("expected fired=true when matching comment is from a collaborator")
+	}
+	if data == nil || data["gate_approved"] != true {
+		t.Error("expected gate_approved=true in data")
+	}
+	if data["gate_comment_author"] != "contributor" {
+		t.Errorf("expected gate_comment_author=contributor, got %v", data["gate_comment_author"])
+	}
+}
+
 func TestCheckGateApproved_DefaultTrigger_IsLabelAdded(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
@@ -2299,6 +2393,107 @@ func TestCheckPlanUserReplied_ApprovalPatternNoMatch(t *testing.T) {
 	}
 	if data["plan_approved"] != false {
 		t.Errorf("expected plan_approved=false when comment does not match approval_pattern, got %v", data["plan_approved"])
+	}
+}
+
+func TestCheckPlanUserReplied_NonCollaboratorCannotApprovePlan(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Matching comment from a non-collaborator.
+	commentsJSON := []byte(`{"comments":[{"author":{"login":"outsider"},"body":"LGTM, ship it","createdAt":"2020-01-01T10:05:00Z"}]}`)
+	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+		Stdout: commentsJSON,
+	})
+	// Collaborator check for "outsider" returns 404 (not a collaborator).
+	mockExec.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/collaborators/outsider"}, exec.MockResponse{
+		Err: fmt.Errorf("HTTP 404: Not Found"),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "42"},
+		SessionID:   "sess-1",
+		CurrentStep: "plan_review",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{"approval_pattern": "^LGTM"})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+	view.StepEnteredAt = time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	fired, data, err := checker.checkPlanUserReplied(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Event still fires (comment was posted), but plan_approved must be false.
+	if !fired {
+		t.Error("expected fired=true since a comment was posted")
+	}
+	if data["plan_approved"] != false {
+		t.Errorf("expected plan_approved=false for non-collaborator approval attempt, got %v", data["plan_approved"])
+	}
+	if data["user_feedback_author"] != "outsider" {
+		t.Errorf("expected user_feedback_author=outsider, got %v", data["user_feedback_author"])
+	}
+}
+
+func TestCheckPlanUserReplied_CollaboratorCanApprovePlan(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Matching comment from a collaborator.
+	commentsJSON := []byte(`{"comments":[{"author":{"login":"contributor"},"body":"LGTM, proceed","createdAt":"2020-01-01T10:05:00Z"}]}`)
+	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+		Stdout: commentsJSON,
+	})
+	// Collaborator check for "contributor" succeeds (HTTP 204 → no error).
+	mockExec.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/collaborators/contributor"}, exec.MockResponse{
+		Stdout: []byte(``),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "42"},
+		SessionID:   "sess-1",
+		CurrentStep: "plan_review",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(map[string]any{"approval_pattern": "^LGTM"})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+	view.StepEnteredAt = time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	fired, data, err := checker.checkPlanUserReplied(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fired {
+		t.Error("expected fired=true when collaborator posts matching comment")
+	}
+	if data["plan_approved"] != true {
+		t.Errorf("expected plan_approved=true for collaborator approval, got %v", data["plan_approved"])
+	}
+	if data["user_feedback_author"] != "contributor" {
+		t.Errorf("expected user_feedback_author=contributor, got %v", data["user_feedback_author"])
 	}
 }
 

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -434,6 +434,18 @@ func (s *GitService) CheckIssueHasLabel(ctx context.Context, repoPath string, is
 	return false, nil
 }
 
+// CheckUserIsCollaborator returns true if the given GitHub username is a
+// collaborator (has explicit repository access) on the repo at repoPath.
+// Uses `gh api repos/:owner/:repo/collaborators/{username}` which returns
+// HTTP 204 if the user is a collaborator or HTTP 404 if not.
+// Any error (including 404) is treated as "not a collaborator".
+func (s *GitService) CheckUserIsCollaborator(ctx context.Context, repoPath, username string) (bool, error) {
+	_, err := s.executor.Output(ctx, repoPath, "gh", "api",
+		fmt.Sprintf("repos/:owner/:repo/collaborators/%s", username),
+	)
+	return err == nil, nil
+}
+
 // GetIssueComments fetches all comments on a GitHub issue using the gh CLI.
 // Uses `gh issue view --json comments` to retrieve the full comment list.
 func (s *GitService) GetIssueComments(ctx context.Context, repoPath string, issueNumber int) ([]IssueComment, error) {

--- a/internal/git/github_test.go
+++ b/internal/git/github_test.go
@@ -3120,3 +3120,35 @@ func TestGetPRNumber_InvalidJSON(t *testing.T) {
 		t.Fatal("expected parse error, got nil")
 	}
 }
+
+func TestCheckUserIsCollaborator_IsCollaborator(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/collaborators/alice"}, pexec.MockResponse{
+		Stdout: []byte(`{}`), // 204 response has no body, but we return empty JSON
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	isCollab, err := svc.CheckUserIsCollaborator(context.Background(), "/repo", "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isCollab {
+		t.Error("expected alice to be a collaborator")
+	}
+}
+
+func TestCheckUserIsCollaborator_NotCollaborator(t *testing.T) {
+	mock := pexec.NewMockExecutor(nil)
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/collaborators/outsider"}, pexec.MockResponse{
+		Err: fmt.Errorf("HTTP 404: Not Found"),
+	})
+
+	svc := NewGitServiceWithExecutor(mock)
+	isCollab, err := svc.CheckUserIsCollaborator(context.Background(), "/repo", "outsider")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isCollab {
+		t.Error("expected outsider to not be a collaborator")
+	}
+}


### PR DESCRIPTION
## Summary
Prevents non-collaborators from approving plans or gates via GitHub issue comments. This is a security hardening measure to ensure only users with repository access can trigger workflow transitions.

## Changes
- Add `CheckUserIsCollaborator` to `GitService` using `gh api repos/:owner/:repo/collaborators/{username}`
- Gate approval comments in `checkGateApproved` behind a collaborator check for GitHub issues
- Gate plan approval comments in `checkPlanUserReplied` behind a collaborator check — non-collaborator comments are still processed as feedback but cannot approve
- Add tests for collaborator checking, gate approval filtering, and plan approval filtering

## Test plan
- `go test -p=1 -count=1 ./internal/git/...` — verifies collaborator check for both collaborator and non-collaborator users
- `go test -p=1 -count=1 ./internal/daemon/...` — verifies gate and plan approval are denied for non-collaborators and allowed for collaborators

Fixes #286