### PR TITLE
Fix: pass approved plan to coding session

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -8511,6 +8511,131 @@ func TestStartPlanning_UsesDefaultPromptWhenNoCustom(t *testing.T) {
 	}
 }
 
+func TestStartCoding_IncludesPlanFromIssueComments(t *testing.T) {
+	cfg := testConfig()
+	cfg.Repos = []string{"/test/repo"}
+
+	mockExec := exec.NewMockExecutor(nil)
+
+	// BranchExists returns false — no pre-existing branch
+	mockExec.AddRule(func(dir, name string, args []string) bool {
+		return name == "git" && len(args) >= 3 && args[0] == "rev-parse" && args[1] == "--verify"
+	}, exec.MockResponse{Err: fmt.Errorf("fatal: Needed a single revision")})
+
+	// Mock gh issue view --json comments to return a plan comment with the marker
+	commentsJSON, _ := json.Marshal(struct {
+		Comments []struct {
+			Author    struct{ Login string } `json:"author"`
+			Body      string                 `json:"body"`
+			CreatedAt string                 `json:"createdAt"`
+		} `json:"comments"`
+	}{
+		Comments: []struct {
+			Author    struct{ Login string } `json:"author"`
+			Body      string                 `json:"body"`
+			CreatedAt string                 `json:"createdAt"`
+		}{
+			{Author: struct{ Login string }{"bot"}, Body: "## Plan\n1. Refactor the widget\n2. Add tests\n" + worker.PlanMarker, CreatedAt: "2026-03-05T10:00:00Z"},
+			{Author: struct{ Login string }{"zhubert"}, Body: "approved", CreatedAt: "2026-03-05T11:00:00Z"},
+		},
+	})
+	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+		Stdout: commentsJSON,
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	sessSvc := session.NewSessionServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.sessionService = sessSvc
+	d.repoFilter = "/test/repo"
+
+	item := &daemonstate.WorkItem{
+		ID:       "work-plan",
+		IssueRef: config.IssueRef{Source: "github", ID: "42", Title: "Refactor widget"},
+		StepData: map[string]any{"issue_body": "Please refactor the widget"},
+	}
+	d.state.AddWorkItem(item)
+
+	err := d.startCoding(t.Context(), *item)
+	if err != nil {
+		t.Fatalf("startCoding failed: %v", err)
+	}
+
+	// Verify the worker's initial message includes the plan
+	d.mu.Lock()
+	w := d.workers["work-plan"]
+	d.mu.Unlock()
+	if w == nil {
+		t.Fatal("expected worker to be registered")
+	}
+
+	msg := w.InitialMsg()
+	if !strings.Contains(msg, "Approved implementation plan:") {
+		t.Errorf("initial message should contain plan header, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Refactor the widget") {
+		t.Errorf("initial message should contain plan content, got:\n%s", msg)
+	}
+	// The marker itself should be stripped from the plan body
+	if strings.Contains(msg, worker.PlanMarker) {
+		t.Errorf("initial message should not contain raw plan marker, got:\n%s", msg)
+	}
+}
+
+func TestStartCoding_NoPlanGracefullyDegraded(t *testing.T) {
+	cfg := testConfig()
+	cfg.Repos = []string{"/test/repo"}
+
+	mockExec := exec.NewMockExecutor(nil)
+
+	// BranchExists returns false
+	mockExec.AddRule(func(dir, name string, args []string) bool {
+		return name == "git" && len(args) >= 3 && args[0] == "rev-parse" && args[1] == "--verify"
+	}, exec.MockResponse{Err: fmt.Errorf("fatal: Needed a single revision")})
+
+	// Mock gh issue view to fail (simulates no comments or API error)
+	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+		Err: fmt.Errorf("network error"),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	sessSvc := session.NewSessionServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.sessionService = sessSvc
+	d.repoFilter = "/test/repo"
+
+	item := &daemonstate.WorkItem{
+		ID:       "work-no-plan",
+		IssueRef: config.IssueRef{Source: "github", ID: "42", Title: "Fix bug"},
+		StepData: map[string]any{"issue_body": "Fix the bug"},
+	}
+	d.state.AddWorkItem(item)
+
+	// Should succeed even when comments can't be fetched
+	err := d.startCoding(t.Context(), *item)
+	if err != nil {
+		t.Fatalf("startCoding should succeed without plan, got: %v", err)
+	}
+
+	d.mu.Lock()
+	w := d.workers["work-no-plan"]
+	d.mu.Unlock()
+	if w == nil {
+		t.Fatal("expected worker to be registered")
+	}
+
+	msg := w.InitialMsg()
+	if strings.Contains(msg, "Approved implementation plan:") {
+		t.Errorf("initial message should NOT contain plan header when no plan exists, got:\n%s", msg)
+	}
+	// But should still have the issue content
+	if !strings.Contains(msg, "Fix bug") {
+		t.Errorf("initial message should contain issue title, got:\n%s", msg)
+	}
+}
+
 // --- cherryPickAction tests ---
 
 func TestCherryPickAction_Execute_WorkItemNotFound(t *testing.T) {

--- a/internal/daemon/coding.go
+++ b/internal/daemon/coding.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	osexec "os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,11 +16,46 @@ import (
 	"github.com/zhubert/erg/internal/config"
 	"github.com/zhubert/erg/internal/daemonstate"
 	"github.com/zhubert/erg/internal/git"
+	"github.com/zhubert/erg/internal/issues"
 	"github.com/zhubert/erg/internal/paths"
 	"github.com/zhubert/erg/internal/session"
 	"github.com/zhubert/erg/internal/worker"
 	"github.com/zhubert/erg/internal/workflow"
 )
+
+// fetchIssueComments retrieves comments for a work item's issue from the appropriate provider.
+func (d *Daemon) fetchIssueComments(ctx context.Context, repoPath string, item daemonstate.WorkItem) ([]issues.IssueComment, error) {
+	source := item.IssueRef.Source
+
+	if source == "github" {
+		issueNumber, err := strconv.Atoi(item.IssueRef.ID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid github issue number %q: %w", item.IssueRef.ID, err)
+		}
+		gitComments, err := d.gitService.GetIssueComments(ctx, repoPath, issueNumber)
+		if err != nil {
+			return nil, err
+		}
+		result := make([]issues.IssueComment, len(gitComments))
+		for i, gc := range gitComments {
+			result[i] = issues.IssueComment{Author: gc.Author, Body: gc.Body, CreatedAt: gc.CreatedAt}
+		}
+		return result, nil
+	}
+
+	if d.issueRegistry == nil {
+		return nil, fmt.Errorf("no issue registry configured for source %q", source)
+	}
+	p := d.issueRegistry.GetProvider(issues.Source(source))
+	if p == nil {
+		return nil, fmt.Errorf("no provider found for source %q", source)
+	}
+	gc, ok := p.(issues.ProviderGateChecker)
+	if !ok {
+		return nil, fmt.Errorf("provider for source %q does not support fetching comments", source)
+	}
+	return gc.GetIssueComments(ctx, repoPath, item.IssueRef.ID)
+}
 
 // startPlanning creates a read-only planning session and starts a Claude worker to analyze
 // the issue and codebase, then post a structured implementation plan as an issue comment.
@@ -251,6 +287,17 @@ func (d *Daemon) startCoding(ctx context.Context, item daemonstate.WorkItem) err
 	// Build initial message using provider-aware formatting
 	issueBody, _ := item.StepData["issue_body"].(string)
 	initialMsg := worker.FormatInitialMessage(item.IssueRef, issueBody)
+
+	// If a planning phase produced an approved plan, fetch it from the issue
+	// comments and include it so the coding session knows what to implement.
+	planCtx, planCancel := context.WithTimeout(ctx, timeoutQuickAPI)
+	comments, planErr := d.fetchIssueComments(planCtx, repoPath, item)
+	planCancel()
+	if planErr != nil {
+		log.Debug("could not fetch issue comments for plan context", "error", planErr)
+	} else if plan := worker.FindPlanComment(comments); plan != "" {
+		initialMsg += "\n\n---\nApproved implementation plan:\n" + plan
+	}
 
 	// Resolve coding system prompt from workflow config
 	systemPrompt := params.String("system_prompt", "")

--- a/internal/worker/helpers.go
+++ b/internal/worker/helpers.go
@@ -62,6 +62,24 @@ func FilterTranscriptComments(comments []git.PRReviewComment) []git.PRReviewComm
 	return filtered
 }
 
+// PlanMarker is the HTML comment marker appended to plan comments posted during
+// planning sessions. It allows the coding session to identify and include the
+// approved plan in its initial context.
+const PlanMarker = "<!-- erg:plan -->"
+
+// FindPlanComment returns the body of the most recent plan comment (identified
+// by PlanMarker) from a slice of issue comments. Returns "" if no plan is found.
+// The marker is stripped from the returned body.
+func FindPlanComment(comments []issues.IssueComment) string {
+	// Walk backwards to find the most recent plan.
+	for i := len(comments) - 1; i >= 0; i-- {
+		if strings.Contains(comments[i].Body, PlanMarker) {
+			return strings.TrimSpace(strings.ReplaceAll(comments[i].Body, PlanMarker, ""))
+		}
+	}
+	return ""
+}
+
 // FormatInitialMessage formats the initial message for a coding session based on the issue provider.
 // The optional body parameter contains the issue description/body text.
 func FormatInitialMessage(ref config.IssueRef, body string) string {

--- a/internal/worker/helpers_test.go
+++ b/internal/worker/helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/zhubert/erg/internal/config"
 	"github.com/zhubert/erg/internal/git"
+	"github.com/zhubert/erg/internal/issues"
 )
 
 func TestTrimURL(t *testing.T) {
@@ -256,4 +257,60 @@ func TestFormatInitialMessage_BodyPlacement(t *testing.T) {
 			t.Errorf("expected %q, got %q", expected, result)
 		}
 	})
+}
+
+func TestFindPlanComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		comments []issues.IssueComment
+		want     string
+	}{
+		{
+			name:     "no comments",
+			comments: nil,
+			want:     "",
+		},
+		{
+			name: "no plan marker",
+			comments: []issues.IssueComment{
+				{Body: "some random comment"},
+				{Body: "another comment"},
+			},
+			want: "",
+		},
+		{
+			name: "single plan comment",
+			comments: []issues.IssueComment{
+				{Body: "## Plan\n1. Do stuff\n<!-- erg:plan -->"},
+			},
+			want: "## Plan\n1. Do stuff",
+		},
+		{
+			name: "returns most recent plan when multiple exist",
+			comments: []issues.IssueComment{
+				{Body: "Old plan\n<!-- erg:plan -->"},
+				{Body: "user feedback"},
+				{Body: "Revised plan\n<!-- erg:plan -->"},
+			},
+			want: "Revised plan",
+		},
+		{
+			name: "ignores non-plan comments interspersed",
+			comments: []issues.IssueComment{
+				{Body: "The plan\n<!-- erg:plan -->"},
+				{Body: "LGTM"},
+				{Body: "<!-- erg:step=await_plan_feedback -->"},
+			},
+			want: "The plan",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindPlanComment(tt.comments)
+			if got != tt.want {
+				t.Errorf("FindPlanComment() = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -588,7 +588,12 @@ func (w *SessionWorker) handleCommentIssue(req mcp.CommentIssueRequest) {
 	log := w.host.Logger().With("sessionID", w.sessionID)
 	log.Info("posting issue comment via MCP tool")
 
-	if err := w.host.CommentOnIssue(w.ctx, w.sessionID, req.Body); err != nil {
+	body := req.Body
+	if w.planningMode {
+		body += "\n<!-- erg:plan -->"
+	}
+
+	if err := w.host.CommentOnIssue(w.ctx, w.sessionID, body); err != nil {
 		w.runner.SendCommentIssueResponse(mcp.CommentIssueResponse{
 			ID:    req.ID,
 			Error: fmt.Sprintf("Failed to post comment: %v", err),

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -827,6 +828,33 @@ func TestSessionWorker_HandleCommentIssue_Success(t *testing.T) {
 	}
 	if call.Body != "Here is the plan" {
 		t.Errorf("expected body 'Here is the plan', got %q", call.Body)
+	}
+}
+
+func TestSessionWorker_HandleCommentIssue_PlanningModeAppendsPlanMarker(t *testing.T) {
+	mockExec := exec.NewMockExecutor(nil)
+	h := newMockHost(mockExec)
+
+	sess := &config.Session{ID: "s1", RepoPath: "/repo", Branch: "feat-1"}
+	h.cfg.AddSession(*sess)
+
+	runner := claude.NewMockRunner("s1", false, nil)
+	runner.SetHostTools(true)
+	w := NewSessionWorker(h, sess, runner, "test")
+	w.ctx = context.Background()
+	w.SetPlanningMode(true)
+
+	w.handleCommentIssue(mcp.CommentIssueRequest{ID: 1, Body: "## Plan\n1. Do stuff"})
+
+	if len(h.commentOnIssueCalls) != 1 {
+		t.Fatalf("expected 1 CommentOnIssue call, got %d", len(h.commentOnIssueCalls))
+	}
+	call := h.commentOnIssueCalls[0]
+	if !strings.Contains(call.Body, PlanMarker) {
+		t.Errorf("expected plan marker in body, got %q", call.Body)
+	}
+	if !strings.Contains(call.Body, "## Plan\n1. Do stuff") {
+		t.Errorf("expected original plan content in body, got %q", call.Body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The coding session was only receiving the issue title/body, completely losing the approved plan from the planning phase
- Plan comments posted during planning are now tagged with `<!-- erg:plan -->` marker
- `startCoding` fetches issue comments, finds the most recent plan by marker, and includes it in the initial message
- Gracefully degrades if comments can't be fetched (same behavior as before)

## Test plan
- [x] `TestFindPlanComment` — finds most recent plan, handles no plan, multiple revisions
- [x] `TestSessionWorker_HandleCommentIssue_PlanningModeAppendsPlanMarker` — marker appended in planning mode only
- [x] `TestStartCoding_IncludesPlanFromIssueComments` — plan included in worker's initial message
- [x] `TestStartCoding_NoPlanGracefullyDegraded` — coding proceeds without plan on fetch failure
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)