### PR TITLE
Forward XDG env vars in brew service

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,10 @@ brews:
     service: |
       run [opt_bin/"erg", "start", "-f"]
       keep_alive true
-      environment_variables PATH: "#{Dir.home}/.local/bin:#{std_service_path_env}"
+      environment_variables PATH: "#{Dir.home}/.local/bin:#{std_service_path_env}",
+                              XDG_CONFIG_HOME: ENV.fetch("XDG_CONFIG_HOME", ""),
+                              XDG_DATA_HOME: ENV.fetch("XDG_DATA_HOME", ""),
+                              XDG_STATE_HOME: ENV.fetch("XDG_STATE_HOME", "")
       working_dir var/"erg"
       log_path var/"log/erg/daemon.log"
       error_log_path var/"log/erg/daemon.err.log"


### PR DESCRIPTION
## Summary
- Forward `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_STATE_HOME` from the user's shell into the brew service definition
- Prevents the brew service from creating `~/.erg/` when XDG directories are configured, which would permanently override XDG paths due to the legacy-first resolution order

## Context
When `brew services start erg` launches the daemon via launchd, XDG env vars aren't available. Path resolution falls to the default (`~/.erg/`), `MkdirAll` creates the directory, and then `~/.erg/` permanently takes precedence — even in shell sessions where XDG vars are set.

After applying this fix, users should:
1. `rm -rf ~/.erg`
2. `brew services restart erg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)