### PR TITLE
docs: update tagline to descriptive copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # erg
 
-**Autonomous headless daemon for Claude Code** — does the work.
+**Workflow-driven autonomous coding daemon for Claude Code.**
 
 **Docs: [zhubert.com/erg](https://zhubert.com/erg/)** — setup, workflow configuration, CLI reference, and more.
 

--- a/docs/actions.html
+++ b/docs/actions.html
@@ -6,7 +6,7 @@
     <title>Action reference — erg</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -6,7 +6,7 @@
     <title>CLI commands — erg</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/events.html
+++ b/docs/events.html
@@ -6,7 +6,7 @@
     <title>Wait events — erg</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -6,7 +6,7 @@
     <title>Example workflows — erg</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>erg - autonomous headless daemon for claude code</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -1259,7 +1259,7 @@
         <section id="overview">
           <span class="hero-badge">autonomous coding daemon</span>
           <p class="hero-tagline">
-            <span class="hero-tagline-accent">does the work.</span>
+            <span class="hero-tagline-accent">workflow-driven.</span>
           </p>
           <p>
             Autonomous headless daemon for Claude Code. Polls GitHub, Asana, or

--- a/docs/multi-repo.html
+++ b/docs/multi-repo.html
@@ -6,7 +6,7 @@
     <title>Multi-repo — erg</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/workflow.html
+++ b/docs/workflow.html
@@ -6,7 +6,7 @@
     <title>Workflow configuration — erg</title>
     <meta
       name="description"
-      content="erg does the work. Autonomous headless daemon for Claude Code."
+      content="erg — workflow-driven autonomous coding daemon for Claude Code."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
Replaces the "does the work." tagline with more descriptive copy across the README and all docs pages.

## Changes
- Update README tagline to "Workflow-driven autonomous coding daemon for Claude Code."
- Update meta description tags across all docs HTML pages
- Update hero tagline on the landing page to "workflow-driven."

## Test plan
- Verify README renders correctly on GitHub
- Open docs pages locally and confirm meta descriptions and hero text are updated

Fixes #295