### PR TITLE
fix(dashboard): eliminate hover flicker and pin logs to bottom

### DIFF
--- a/internal/dashboard/index.html
+++ b/internal/dashboard/index.html
@@ -696,11 +696,13 @@
     content.querySelectorAll('.log-container[data-id]').forEach(container => {
       const lv = container.querySelector('.log-viewer');
       if (!lv) return;
+      const wasAtBottom = isAtBottom(lv);
+      const session = container.dataset.session;
       container.removeChild(lv);
       savedLogViewers.set(container.dataset.id, {
         element: lv,
-        wasAtBottom: isAtBottom(lv),
-        session: container.dataset.session,
+        wasAtBottom,
+        session,
       });
     });
 


### PR DESCRIPTION
## Summary
Fixes two UX issues in the live dashboard: hover state flickering on work items during re-renders, and log viewers not staying scrolled to the bottom.

## Changes
- Track hovered item ID across re-renders and apply a `js-hovered` CSS class to preserve hover styling through DOM updates
- Add `mouseenter`/`mouseleave` listeners to maintain hover state independently of CSS `:hover` which breaks on re-render
- Pin all `.log-viewer` elements to the bottom after each render so new log lines are always visible

## Test plan
- Open the dashboard with active sessions
- Hover over work items and confirm no flickering when the view re-renders via SSE updates
- Expand a session's log viewer and confirm it stays scrolled to the bottom as new logs arrive
- Verify hover styling still works normally (highlight on enter, remove on leave)

Fixes #323