### PR TITLE
feat(templates): add simplify param to builtin templates

### DIFF
--- a/.erg/workflow.yaml
+++ b/.erg/workflow.yaml
@@ -17,6 +17,8 @@ states:
   code:
     type: template
     use: builtin:code
+    params:
+      simplify: true
     exits:
       success: pr
       failure: notify_failed
@@ -31,6 +33,8 @@ states:
   ci:
     type: template
     use: builtin:ci
+    params:
+      simplify: true
     exits:
       success: review
       failure: notify_failed
@@ -38,6 +42,8 @@ states:
   review:
     type: template
     use: builtin:review
+    params:
+      simplify: true
     exits:
       success: done
       failure: notify_failed

--- a/internal/workflow/defaults.go
+++ b/internal/workflow/defaults.go
@@ -295,6 +295,9 @@ func CodeTemplateConfig() *TemplateConfig {
 			"success": "code_done",
 			"failure": "code_failed",
 		},
+		Params: []TemplateParam{
+			{Name: "simplify", Default: false},
+		},
 		States: map[string]*State{
 			"coding": {
 				Type:   StateTypeTask,
@@ -303,6 +306,7 @@ func CodeTemplateConfig() *TemplateConfig {
 					"max_turns":     50,
 					"max_duration":  "30m",
 					"containerized": true,
+					"simplify":      "{{simplify}}",
 				},
 				Next:  "code_done",
 				Error: "code_failed",
@@ -357,6 +361,9 @@ func CITemplateConfig() *TemplateConfig {
 			"success": "ci_done",
 			"failure": "ci_failed",
 		},
+		Params: []TemplateParam{
+			{Name: "simplify", Default: false},
+		},
 		States: map[string]*State{
 			"await_ci": {
 				Type:    StateTypeWait,
@@ -393,6 +400,7 @@ func CITemplateConfig() *TemplateConfig {
 				Action: "ai.resolve_conflicts",
 				Params: map[string]any{
 					"max_conflict_rounds": 3,
+					"simplify":            "{{simplify}}",
 				},
 				Next:  "push_conflict_fix",
 				Error: "ci_failed",
@@ -409,6 +417,7 @@ func CITemplateConfig() *TemplateConfig {
 				Action: "ai.fix_ci",
 				Params: map[string]any{
 					"max_ci_fix_rounds": 3,
+					"simplify":          "{{simplify}}",
 				},
 				Next:  "push_ci_fix",
 				Error: "ci_unfixable",
@@ -458,13 +467,16 @@ func ReviewTemplateConfig() *TemplateConfig {
 			"success": "review_done",
 			"failure": "review_failed",
 		},
+		Params: []TemplateParam{
+			{Name: "simplify", Default: false},
+		},
 		States: map[string]*State{
 			"await_review": {
 				Type:    StateTypeWait,
 				Event:   "pr.reviewed",
 				Timeout: &Duration{48 * time.Hour},
 				Params: map[string]any{
-					"auto_address":       true,
+					"auto_address":        true,
 					"max_feedback_rounds": 3,
 				},
 				Next:        "check_review_result",
@@ -485,6 +497,7 @@ func ReviewTemplateConfig() *TemplateConfig {
 				Action: "ai.address_review",
 				Params: map[string]any{
 					"max_review_rounds": 3,
+					"simplify":          "{{simplify}}",
 				},
 				Next:  "push_review_fix",
 				Error: "review_failed",

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -250,6 +250,14 @@ func applyParamSubstitution(state *State, params map[string]any) {
 	}
 	for k, v := range state.Params {
 		if s, ok := v.(string); ok {
+			// When the entire value is a single {{name}} placeholder, replace it
+			// with the typed value from params (preserving bool, int, etc.).
+			if m := paramPlaceholder.FindStringSubmatch(s); m != nil && m[0] == s {
+				if val, ok := params[m[1]]; ok {
+					state.Params[k] = val
+					continue
+				}
+			}
 			state.Params[k] = substituteParams(s, params)
 		}
 	}

--- a/internal/workflow/template_test.go
+++ b/internal/workflow/template_test.go
@@ -178,8 +178,9 @@ states:
 		t.Fatal("_t_start_coding missing")
 	}
 	p := NewParamHelper(codingState.Params)
-	if p.String("max_turns", "") != "25" {
-		t.Errorf("max_turns param substitution: got %q, want 25", p.String("max_turns", ""))
+	// Whole-value placeholders preserve the typed value from the override.
+	if p.Int("max_turns", 0) != 25 {
+		t.Errorf("max_turns param substitution: got %v, want 25", p.Raw("max_turns"))
 	}
 	if p.String("method", "") != "squash" {
 		t.Errorf("method param substitution: got %q, want squash", p.String("method", ""))
@@ -237,6 +238,98 @@ states:
 	if p.String("label", "") != "default_value" {
 		t.Errorf("default param: got %q, want default_value", p.String("label", ""))
 	}
+}
+
+func TestExpandTemplates_TypedParamSubstitution(t *testing.T) {
+	dir := t.TempDir()
+	templateYAML := `
+template: typed
+entry: step
+exits:
+  success: done
+  failure: failed
+params:
+  - name: simplify
+    default: false
+  - name: count
+    default: 10
+states:
+  step:
+    type: task
+    action: ai.code
+    params:
+      simplify: "{{simplify}}"
+      count: "{{count}}"
+      label: "prefix-{{count}}-suffix"
+    next: done
+    error: failed
+  done:
+    type: succeed
+  failed:
+    type: fail
+`
+	writeTemplateFile(t, dir, ".erg/templates/typed.yaml", templateYAML)
+
+	t.Run("bool override preserved as typed value", func(t *testing.T) {
+		cfg := minimalCfg(map[string]*State{
+			"start": {
+				Type:   StateTypeTemplate,
+				Use:    ".erg/templates/typed.yaml",
+				Params: map[string]any{"simplify": true},
+				Exits:  map[string]string{"success": "done", "failure": "failed"},
+			},
+		})
+		result, err := ExpandTemplates(cfg, dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p := NewParamHelper(result.States["_t_start_step"].Params)
+		if p.Bool("simplify", false) != true {
+			t.Errorf("expected simplify=true (bool), got %v (%T)", p.Raw("simplify"), p.Raw("simplify"))
+		}
+	})
+
+	t.Run("default bool preserved as typed value", func(t *testing.T) {
+		cfg := minimalCfg(map[string]*State{
+			"start": {
+				Type:  StateTypeTemplate,
+				Use:   ".erg/templates/typed.yaml",
+				Exits: map[string]string{"success": "done", "failure": "failed"},
+			},
+		})
+		result, err := ExpandTemplates(cfg, dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p := NewParamHelper(result.States["_t_start_step"].Params)
+		if p.Bool("simplify", true) != false {
+			t.Errorf("expected simplify=false (default), got %v (%T)", p.Raw("simplify"), p.Raw("simplify"))
+		}
+	})
+
+	t.Run("embedded placeholder still does string substitution", func(t *testing.T) {
+		cfg := minimalCfg(map[string]*State{
+			"start": {
+				Type:   StateTypeTemplate,
+				Use:    ".erg/templates/typed.yaml",
+				Params: map[string]any{"count": 42},
+				Exits:  map[string]string{"success": "done", "failure": "failed"},
+			},
+		})
+		result, err := ExpandTemplates(cfg, dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		p := NewParamHelper(result.States["_t_start_step"].Params)
+		// Whole-value placeholder: typed int preserved
+		if p.Int("count", 0) != 42 {
+			t.Errorf("expected count=42 (int), got %v (%T)", p.Raw("count"), p.Raw("count"))
+		}
+		// Embedded placeholder: string substitution
+		if p.String("label", "") != "prefix-42-suffix" {
+			t.Errorf("expected label=prefix-42-suffix, got %q", p.String("label", ""))
+		}
+	})
 }
 
 func TestExpandTemplates_StateNamespacing(t *testing.T) {
@@ -467,8 +560,8 @@ func TestExpandTemplates_CallerMapsUndeclaredExit(t *testing.T) {
 			Type: StateTypeTemplate,
 			Use:  ".erg/templates/simple.yaml",
 			Exits: map[string]string{
-				"success":     "done",
-				"undeclared":  "done", // template doesn't declare this exit
+				"success":    "done",
+				"undeclared": "done", // template doesn't declare this exit
 			},
 		},
 	})
@@ -485,8 +578,8 @@ func TestExpandTemplates_CallerMapsUndeclaredExit(t *testing.T) {
 func TestExpandTemplates_FileNotFound(t *testing.T) {
 	cfg := minimalCfg(map[string]*State{
 		"start": {
-			Type: StateTypeTemplate,
-			Use:  ".erg/templates/nonexistent.yaml",
+			Type:  StateTypeTemplate,
+			Use:   ".erg/templates/nonexistent.yaml",
 			Exits: map[string]string{"success": "done"},
 		},
 	})
@@ -500,12 +593,11 @@ func TestExpandTemplates_FileNotFound(t *testing.T) {
 	}
 }
 
-
 func TestExpandTemplates_UnknownBuiltin(t *testing.T) {
 	cfg := minimalCfg(map[string]*State{
 		"start": {
-			Type: StateTypeTemplate,
-			Use:  "builtin:nonexistent",
+			Type:  StateTypeTemplate,
+			Use:   "builtin:nonexistent",
 			Exits: map[string]string{"success": "done"},
 		},
 	})
@@ -1011,8 +1103,8 @@ states:
 func TestExpandTemplates_AbsolutePathRejected(t *testing.T) {
 	cfg := minimalCfg(map[string]*State{
 		"start": {
-			Type: StateTypeTemplate,
-			Use:  "/etc/passwd",
+			Type:  StateTypeTemplate,
+			Use:   "/etc/passwd",
 			Exits: map[string]string{"success": "done"},
 		},
 	})
@@ -1031,8 +1123,8 @@ func TestExpandTemplates_AbsolutePathRejected(t *testing.T) {
 func TestExpandTemplates_PathTraversalRejected(t *testing.T) {
 	cfg := minimalCfg(map[string]*State{
 		"start": {
-			Type: StateTypeTemplate,
-			Use:  "../../etc/passwd",
+			Type:  StateTypeTemplate,
+			Use:   "../../etc/passwd",
 			Exits: map[string]string{"success": "done"},
 		},
 	})
@@ -1235,6 +1327,110 @@ func TestExpandTemplates_BuiltinCode(t *testing.T) {
 	}
 	if coding.Action != "ai.code" {
 		t.Errorf("coding.action: got %q, want ai.code", coding.Action)
+	}
+}
+
+func TestExpandTemplates_BuiltinCodeSimplify(t *testing.T) {
+	cfg := minimalCfg(map[string]*State{
+		"start": {
+			Type: StateTypeTemplate,
+			Use:  "builtin:code",
+			Params: map[string]any{
+				"simplify": true,
+			},
+			Exits: map[string]string{
+				"success": "done",
+				"failure": "failed",
+			},
+		},
+	})
+	cfg.Start = "start"
+
+	result, err := ExpandTemplates(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	coding := result.States["_t_start_coding"]
+	if coding == nil {
+		t.Fatal("_t_start_coding missing")
+	}
+	p := NewParamHelper(coding.Params)
+	if p.Bool("simplify", false) != true {
+		t.Errorf("simplify: got %v (%T), want true (bool)", p.Raw("simplify"), p.Raw("simplify"))
+	}
+}
+
+func TestExpandTemplates_BuiltinCISimplify(t *testing.T) {
+	cfg := minimalCfg(map[string]*State{
+		"start": {
+			Type: StateTypeTemplate,
+			Use:  "builtin:ci",
+			Params: map[string]any{
+				"simplify": true,
+			},
+			Exits: map[string]string{
+				"success": "done",
+				"failure": "failed",
+			},
+		},
+	})
+	cfg.Start = "start"
+
+	result, err := ExpandTemplates(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check ai.fix_ci state
+	fixCI := result.States["_t_start_fix_ci"]
+	if fixCI == nil {
+		t.Fatal("_t_start_fix_ci missing")
+	}
+	p := NewParamHelper(fixCI.Params)
+	if p.Bool("simplify", false) != true {
+		t.Errorf("fix_ci simplify: got %v (%T), want true (bool)", p.Raw("simplify"), p.Raw("simplify"))
+	}
+
+	// Check ai.resolve_conflicts state
+	rc := result.States["_t_start_resolve_conflicts"]
+	if rc == nil {
+		t.Fatal("_t_start_resolve_conflicts missing")
+	}
+	p = NewParamHelper(rc.Params)
+	if p.Bool("simplify", false) != true {
+		t.Errorf("resolve_conflicts simplify: got %v (%T), want true (bool)", p.Raw("simplify"), p.Raw("simplify"))
+	}
+}
+
+func TestExpandTemplates_BuiltinReviewSimplify(t *testing.T) {
+	cfg := minimalCfg(map[string]*State{
+		"start": {
+			Type: StateTypeTemplate,
+			Use:  "builtin:review",
+			Params: map[string]any{
+				"simplify": true,
+			},
+			Exits: map[string]string{
+				"success": "done",
+				"failure": "failed",
+			},
+		},
+	})
+	cfg.Start = "start"
+
+	result, err := ExpandTemplates(cfg, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ar := result.States["_t_start_address_review"]
+	if ar == nil {
+		t.Fatal("_t_start_address_review missing")
+	}
+	p := NewParamHelper(ar.Params)
+	if p.Bool("simplify", false) != true {
+		t.Errorf("address_review simplify: got %v (%T), want true (bool)", p.Raw("simplify"), p.Raw("simplify"))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Enhanced template param substitution to preserve typed values (bool, int, etc.) when the entire param value is a single `{{name}}` placeholder, instead of always converting to string
- Added `simplify` as a template param (default: `false`) to `builtin:code`, `builtin:ci`, and `builtin:review` templates, flowing through to `ai.code`, `ai.fix_ci`, `ai.resolve_conflicts`, and `ai.address_review` actions
- Enabled `simplify: true` in the erg workflow config

## Test plan
- [x] New tests for typed param substitution (bool, int, embedded vs whole-value)
- [x] New tests for builtin code/ci/review templates with simplify override
- [x] Existing param substitution tests updated and passing
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)