### PR TITLE
Fix expired keychain OAuth token preventing auto-refresh

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -90,7 +90,7 @@ func daemonize(cmd *cobra.Command, args []string) error {
 	// Also refresh when the keychain entry exists but the token is expired —
 	// otherwise ContainerAuthSource() returns "" and we'd skip the refresh.
 	authSource := claude.ContainerAuthSource()
-	if strings.Contains(authSource, "keychain") || claude.KeychainNeedsRefresh() {
+	if strings.Contains(authSource, "keychain") || (authSource == "" && claude.KeychainNeedsRefresh()) {
 		if out, err := exec.Command("claude", "-v").Output(); err == nil {
 			fmt.Printf("Claude: %s\n", strings.TrimSpace(string(out)))
 		}
@@ -360,7 +360,7 @@ func runForeground(_ *cobra.Command, _ []string) error {
 	// Also refresh when the keychain entry exists but the token is expired —
 	// otherwise ContainerAuthSource() returns "" and we'd skip the refresh.
 	authSource := claude.ContainerAuthSource()
-	if strings.Contains(authSource, "keychain") || claude.KeychainNeedsRefresh() {
+	if strings.Contains(authSource, "keychain") || (authSource == "" && claude.KeychainNeedsRefresh()) {
 		if out, err := exec.Command("claude", "-v").Output(); err == nil {
 			fmt.Printf("Claude: %s\n", strings.TrimSpace(string(out)))
 		}

--- a/internal/claude/container_auth.go
+++ b/internal/claude/container_auth.go
@@ -197,6 +197,14 @@ type keychainOAuthCredentials struct {
 	} `json:"claudeAiOauth"`
 }
 
+// oauthNeedsRefresh checks parsed keychain OAuth credentials and returns true
+// when the access token is missing or expired. This is the shared decision
+// logic used by both readKeychainOAuthToken and KeychainNeedsRefresh.
+func oauthNeedsRefresh(creds keychainOAuthCredentials) bool {
+	return creds.ClaudeAiOauth.AccessToken == "" ||
+		(creds.ClaudeAiOauth.ExpiresAt > 0 && time.Now().UnixMilli() >= creds.ClaudeAiOauth.ExpiresAt)
+}
+
 // readKeychainOAuthToken reads an OAuth access token from the macOS keychain
 // "Claude Code-credentials" entry, used by Claude Pro/Max subscriptions.
 // Returns empty string if not found, expired, on error, or on non-macOS platforms.
@@ -211,12 +219,7 @@ func readKeychainOAuthToken() string {
 		return ""
 	}
 
-	if creds.ClaudeAiOauth.AccessToken == "" {
-		return ""
-	}
-
-	// Check if token is expired
-	if creds.ClaudeAiOauth.ExpiresAt > 0 && time.Now().UnixMilli() >= creds.ClaudeAiOauth.ExpiresAt {
+	if oauthNeedsRefresh(creds) {
 		return ""
 	}
 
@@ -238,9 +241,7 @@ func KeychainNeedsRefresh() bool {
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		return false
 	}
-	// Entry exists — needs refresh if token is empty or expired.
-	return creds.ClaudeAiOauth.AccessToken == "" ||
-		(creds.ClaudeAiOauth.ExpiresAt > 0 && time.Now().UnixMilli() >= creds.ClaudeAiOauth.ExpiresAt)
+	return oauthNeedsRefresh(creds)
 }
 
 // credentialsFileExists checks whether ~/.claude/.credentials.json exists.

--- a/internal/claude/process_manager_test.go
+++ b/internal/claude/process_manager_test.go
@@ -1890,9 +1890,8 @@ func TestKeychainNeedsRefresh_ExpiredTokenDetection(t *testing.T) {
 				}
 				return
 			}
-			// Replicate the logic in KeychainNeedsRefresh.
-			needRefresh := creds.ClaudeAiOauth.AccessToken == "" ||
-				(creds.ClaudeAiOauth.ExpiresAt > 0 && time.Now().UnixMilli() >= creds.ClaudeAiOauth.ExpiresAt)
+			// Use the same helper that KeychainNeedsRefresh calls.
+			needRefresh := oauthNeedsRefresh(creds)
 			if needRefresh != tt.needRefresh {
 				t.Errorf("got needRefresh=%v, want %v", needRefresh, tt.needRefresh)
 			}


### PR DESCRIPTION
## Summary
- When the macOS keychain OAuth token was expired, `ContainerAuthSource()` returned `""` (expiry check in `readKeychainOAuthToken`), so the pre-auth `claude -v` refresh never triggered — a catch-22 that caused container sessions to fail immediately with "container mode requires authentication"
- Added `KeychainNeedsRefresh()` that detects expired/missing tokens in existing keychain entries
- Updated both `daemonize()` and `runForeground()` in `cmd/agent.go` to also trigger refresh when keychain needs it

## Test plan
- [x] Added `TestKeychainNeedsRefresh_NonDarwin` for non-macOS behavior
- [x] Added `TestKeychainNeedsRefresh_ExpiredTokenDetection` table-driven tests covering valid, expired, empty, invalid JSON, and empty JSON cases
- [x] Full test suite passes (`go test -p=1 -count=1 ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)