### PR TITLE
fix(dashboard): only show retry button for failed workers

### DIFF
--- a/internal/dashboard/index.html
+++ b/internal/dashboard/index.html
@@ -822,7 +822,7 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
     if (controlEnabled) {
       const id = escapeHtml(item.id);
       const isActive = item.state === 'active';
-      const isFailed = item.state === 'failed' || item.state === 'completed';
+      const isFailed = item.state === 'failed';
       const hasSession = !!item.session_id;
 
       let buttons = '';


### PR DESCRIPTION
## Summary
The retry button was incorrectly shown for successfully completed workers. Now it only appears for failed workers.

## Changes
- Changed the condition for showing the retry button from `failed || completed` to just `failed`

## Test plan
- Open the dashboard and verify completed workers no longer show a retry button
- Verify failed workers still show the retry button

Fixes #354