### PR TITLE
feat(dashboard): show repo name on each work item card

### DIFF
--- a/internal/dashboard/index.html
+++ b/internal/dashboard/index.html
@@ -769,7 +769,7 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
 
     let itemsHtml = '';
     for (const item of sorted) {
-      itemsHtml += renderWorkItem(item);
+      itemsHtml += renderWorkItem(item, daemon.repo);
     }
 
     if (sorted.length === 0) {
@@ -792,7 +792,7 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
     `;
   }
 
-  function renderWorkItem(item) {
+  function renderWorkItem(item, repo) {
     const isExpanded = expandedItems.has(item.id);
     const msgOpen = messagePanelOpen.has(item.id);
     const label = issueLabel(item);
@@ -875,6 +875,10 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
           <span class="item-state-badge ${item.state}">${item.state}</span>
         </div>
         <div class="item-meta">
+          ${repo ? `<div class="meta-item">
+            <span class="meta-label">repo</span>
+            <span class="meta-value">${escapeHtml(repoDisplayName(repo))}</span>
+          </div>` : ''}
           <div class="meta-item">
             <span class="meta-label">step</span>
             <span class="meta-value step">${escapeHtml(step)}</span>


### PR DESCRIPTION
## Summary
Displays the repository name on each work item card in the dashboard, making it easier to identify which repo a work item belongs to in multi-repo setups.

## Changes
- Pass `daemon.repo` through to `renderWorkItem()`
- Render a "repo" meta item on each work item card when repo info is available

## Test plan
- Open the dashboard with one or more repos configured
- Verify each work item card displays the repo name in the metadata section
- Verify no repo label appears when repo info is absent

Fixes #353