### PR TITLE
fix: auto-detect Docker socket for launchd environments

### DIFF
--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -447,12 +448,19 @@ func TestEnsureDockerHost_FindsSocket(t *testing.T) {
 	defer func() { defaultSocketPath = origDefault }()
 	defaultSocketPath = "/nonexistent/default.sock"
 
-	// Create a temp dir with a fake socket file to simulate a runtime socket.
-	tmp := t.TempDir()
-	fakeSock := filepath.Join(tmp, "docker.sock")
-	if err := os.WriteFile(fakeSock, nil, 0o600); err != nil {
+	// Create a real UNIX domain socket to simulate a runtime socket.
+	// Use a short path under /tmp to avoid exceeding the ~104-char unix socket limit.
+	tmp, err := os.MkdirTemp("/tmp", "erg-test-")
+	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(tmp)
+	fakeSock := filepath.Join(tmp, "d.sock")
+	l, err := net.Listen("unix", fakeSock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
 
 	// Override dockerSocketPaths via a helper that injects our fake path.
 	origPaths := dockerSocketPathsFunc

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -49,7 +49,7 @@ var dockerSocketPathsFunc = func() []string {
 			filepath.Join(home, ".docker/run/docker.sock"),     // Docker Desktop (macOS)
 		)
 	}
-	paths = append(paths, "/var/run/docker.sock") // Standard default
+	paths = append(paths, defaultSocketPath) // Standard default
 	return paths
 }
 
@@ -69,7 +69,7 @@ func ensureDockerHost() {
 		return
 	}
 	for _, sock := range dockerSocketPathsFunc() {
-		if _, err := os.Stat(sock); err == nil {
+		if fi, err := os.Stat(sock); err == nil && fi.Mode()&os.ModeSocket != 0 {
 			os.Setenv("DOCKER_HOST", "unix://"+sock)
 			return
 		}


### PR DESCRIPTION
## Summary
- Under launchd (e.g. Homebrew services), Docker CLI context config isn't available, so `docker info` fails even when Colima/OrbStack/Docker Desktop is running
- Added `ensureDockerHost()` that probes well-known socket paths (`~/.colima/default/docker.sock`, `~/.orbstack/run/docker.sock`, `~/.docker/run/docker.sock`, `/var/run/docker.sock`) and sets `DOCKER_HOST` automatically
- No-op when `DOCKER_HOST` is already set or `/var/run/docker.sock` exists

## Test plan
- [x] Unit tests for `ensureDockerHost` (already set, finds socket, no socket found)
- [x] Full test suite passes
- [ ] Manual: restart erg via `brew services restart erg` with Colima running — should no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)