### PR TITLE
fix(git): pass --grep as separate arg to prevent flag injection

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -1785,7 +1785,7 @@ func TestFixCIAction_Execute_MaxRoundsFromGit(t *testing.T) {
 		Stdout: []byte("abc123\n"),
 	})
 	// CountCommitsMatchingMessage: return 3 (max reached)
-	mockExec.AddPrefixMatch("git", []string{"rev-list", "--count", "--grep=" + git.CIFixMarkerMessage}, exec.MockResponse{
+	mockExec.AddPrefixMatch("git", []string{"rev-list", "--count", "--grep", git.CIFixMarkerMessage}, exec.MockResponse{
 		Stdout: []byte("3\n"),
 	})
 
@@ -1830,7 +1830,7 @@ func TestFixCIAction_Execute_GitRoundsBelowMax(t *testing.T) {
 		Stdout: []byte("abc123\n"),
 	})
 	// CountCommitsMatchingMessage: return 1 (one round done, below max of 3)
-	mockExec.AddPrefixMatch("git", []string{"rev-list", "--count", "--grep=" + git.CIFixMarkerMessage}, exec.MockResponse{
+	mockExec.AddPrefixMatch("git", []string{"rev-list", "--count", "--grep", git.CIFixMarkerMessage}, exec.MockResponse{
 		Stdout: []byte("1\n"),
 	})
 	// gh run list (CI logs fetch) — return empty so it falls back to generic message
@@ -1875,7 +1875,7 @@ func TestFixCIAction_Execute_FallsBackToStepDataOnGitError(t *testing.T) {
 		Stdout: []byte("abc123\n"),
 	})
 	// CountCommitsMatchingMessage: git rev-list fails
-	mockExec.AddPrefixMatch("git", []string{"rev-list", "--count", "--grep=" + git.CIFixMarkerMessage}, exec.MockResponse{
+	mockExec.AddPrefixMatch("git", []string{"rev-list", "--count", "--grep", git.CIFixMarkerMessage}, exec.MockResponse{
 		Err: fmt.Errorf("exit status 128"),
 	})
 
@@ -1914,7 +1914,7 @@ func TestCountCIFixRoundsFromGit_UsesRemoteBranch(t *testing.T) {
 		Stdout: []byte("abc123\n"),
 	})
 	// rev-list with origin/main as base
-	mockExec.AddExactMatch("git", []string{"rev-list", "--count", "--grep=" + git.CIFixMarkerMessage, "origin/main..feature"}, exec.MockResponse{
+	mockExec.AddExactMatch("git", []string{"rev-list", "--count", "--grep", git.CIFixMarkerMessage, "origin/main..feature"}, exec.MockResponse{
 		Stdout: []byte("2\n"),
 	})
 
@@ -1942,7 +1942,7 @@ func TestCountCIFixRoundsFromGit_FallsBackToLocalBase(t *testing.T) {
 		Err: fmt.Errorf("exit status 128"),
 	})
 	// rev-list with local main as base
-	mockExec.AddExactMatch("git", []string{"rev-list", "--count", "--grep=" + git.CIFixMarkerMessage, "main..feature"}, exec.MockResponse{
+	mockExec.AddExactMatch("git", []string{"rev-list", "--count", "--grep", git.CIFixMarkerMessage, "main..feature"}, exec.MockResponse{
 		Stdout: []byte("1\n"),
 	})
 

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -30,7 +30,7 @@ func (s *GitService) CreateEmptyCommit(ctx context.Context, worktreePath, messag
 // performs a full-text search against each commit's log message.
 func (s *GitService) CountCommitsMatchingMessage(ctx context.Context, repoPath, branch, baseBranch, grepPattern string) (int, error) {
 	output, err := s.executor.Output(ctx, repoPath, "git", "rev-list", "--count",
-		"--grep="+grepPattern, baseBranch+".."+branch)
+		"--grep", grepPattern, baseBranch+".."+branch)
 	if err != nil {
 		return 0, fmt.Errorf("git rev-list failed: %w", err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3154,7 +3154,7 @@ func TestCreateEmptyCommit_Integration(t *testing.T) {
 
 func TestCountCommitsMatchingMessage_Success(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep=ci-fix: start", "main..feature"}, pexec.MockResponse{
+	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep", "ci-fix: start", "main..feature"}, pexec.MockResponse{
 		Stdout: []byte("2\n"),
 	})
 	s := NewGitServiceWithExecutor(mock)
@@ -3170,7 +3170,7 @@ func TestCountCommitsMatchingMessage_Success(t *testing.T) {
 
 func TestCountCommitsMatchingMessage_Zero(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep=ci-fix: start", "main..feature"}, pexec.MockResponse{
+	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep", "ci-fix: start", "main..feature"}, pexec.MockResponse{
 		Stdout: []byte("0\n"),
 	})
 	s := NewGitServiceWithExecutor(mock)
@@ -3186,7 +3186,7 @@ func TestCountCommitsMatchingMessage_Zero(t *testing.T) {
 
 func TestCountCommitsMatchingMessage_GitError(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep=ci-fix: start", "main..feature"}, pexec.MockResponse{
+	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep", "ci-fix: start", "main..feature"}, pexec.MockResponse{
 		Err: fmt.Errorf("exit status 128"),
 	})
 	s := NewGitServiceWithExecutor(mock)
@@ -3199,7 +3199,7 @@ func TestCountCommitsMatchingMessage_GitError(t *testing.T) {
 
 func TestCountCommitsMatchingMessage_BadOutput(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep=ci-fix: start", "main..feature"}, pexec.MockResponse{
+	mock.AddExactMatch("git", []string{"rev-list", "--count", "--grep", "ci-fix: start", "main..feature"}, pexec.MockResponse{
 		Stdout: []byte("not-a-number\n"),
 	})
 	s := NewGitServiceWithExecutor(mock)


### PR DESCRIPTION
## Summary
Splits the `--grep=<pattern>` argument into `--grep`, `<pattern>` as separate args in `CountCommitsMatchingMessage` to prevent potential git flag injection via crafted grep patterns.

## Changes
- Split combined `--grep=<pattern>` into two separate arguments `--grep` and `<pattern>` in `GitService.CountCommitsMatchingMessage`
- Updated all corresponding mock expectations in git and daemon action tests

## Test plan
- `go test -p=1 -count=1 ./internal/git/... ./internal/daemon/...`
- Existing tests cover success, zero-count, git error, and bad output scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #369