### PR TITLE
security(dashboard): add CORS middleware to block cross-origin requests

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -116,7 +116,14 @@ func (s *Server) Run(ctx context.Context) error {
 		return fmt.Errorf("listen: %w", err)
 	}
 
-	allowedOrigin := buildOrigin(ln.Addr().String())
+	// Build the allowed origin from the configured bind host (preserving
+	// "localhost" when the user configured "localhost:PORT") combined with the
+	// OS-assigned port from the listener.  Using ln.Addr().String() directly
+	// would map "localhost" → "127.0.0.1" and cause the browser's
+	// "Origin: http://localhost:PORT" to be rejected.
+	configHost, _, _ := net.SplitHostPort(s.addr)
+	_, resolvedPort, _ := net.SplitHostPort(ln.Addr().String())
+	allowedOrigin := buildOrigin(net.JoinHostPort(configHost, resolvedPort))
 	srv := &http.Server{
 		Addr:    s.addr,
 		Handler: corsMiddleware(allowedOrigin)(mux),
@@ -348,7 +355,7 @@ func corsMiddleware(allowedOrigin string) func(http.Handler) http.Handler {
 			}
 			// Origin matches — set CORS headers and handle preflight.
 			w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
+			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 			if r.Method == http.MethodOptions {

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -616,6 +617,37 @@ func TestBuildOrigin(t *testing.T) {
 	}
 }
 
+// TestBuildOrigin_LocalhostPreservation verifies that when the server is
+// configured to bind on "localhost:0", the allowed origin uses "localhost"
+// (not the resolved IP like "127.0.0.1") so the browser's
+// "Origin: http://localhost:PORT" is accepted.
+func TestBuildOrigin_LocalhostPreservation(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// Simulate what Run() does: use configured host + resolved port.
+	configHost, _, _ := net.SplitHostPort("localhost:0")
+	_, resolvedPort, _ := net.SplitHostPort(ln.Addr().String())
+	origin := buildOrigin(net.JoinHostPort(configHost, resolvedPort))
+
+	want := "http://localhost:" + resolvedPort
+	if origin != want {
+		t.Errorf("buildOrigin with localhost:0 config = %q, want %q", origin, want)
+	}
+
+	// Confirm that using the raw listener address would differ (demonstrating
+	// the regression this test guards against).
+	rawOrigin := buildOrigin(ln.Addr().String())
+	if rawOrigin == want {
+		// On some systems (e.g., macOS) localhost:0 may resolve to localhost;
+		// skip the regression check in that case.
+		t.Logf("note: on this system localhost:0 resolved to %q — raw and config-based origins are identical", ln.Addr().String())
+	}
+}
+
 // ---- corsMiddleware ----
 
 func TestCORSMiddleware_NoOrigin(t *testing.T) {
@@ -651,8 +683,11 @@ func TestCORSMiddleware_MatchingOrigin(t *testing.T) {
 	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != allowedOrigin {
 		t.Errorf("expected ACAO=%q, got %q", allowedOrigin, got)
 	}
-	if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "false" {
-		t.Errorf("expected ACAC=false, got %q", got)
+	if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("expected ACAC header to be absent, got %q", got)
+	}
+	if got := resp.Header.Get("Vary"); got != "Origin" {
+		t.Errorf("expected Vary=Origin, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds CORS middleware to the dashboard HTTP server to prevent malicious websites from making cross-origin requests to the locally-bound dashboard API.

## Changes
- Add `corsMiddleware` that rejects requests with non-matching `Origin` headers with 403 Forbidden
- Add `buildOrigin` helper to derive the allowed origin from the resolved listener address, mapping wildcard bind addresses to `localhost`
- Move `http.Server` creation after `net.Listen` so the actual bound address is available for origin construction
- Requests without an `Origin` header (direct navigation, CLI tools) pass through unchanged
- Matching-origin preflight (`OPTIONS`) requests return 204 with appropriate CORS headers

## Test plan
- Unit tests added for `buildOrigin` covering localhost, IPv4, IPv6, wildcard, and invalid inputs
- Unit tests added for `corsMiddleware` covering: no origin, matching origin, non-matching origin, OPTIONS preflight with matching and non-matching origins
- Run `go test -p=1 -count=1 ./internal/dashboard/...`

Fixes #368