### PR TITLE
security: restrict NewTCPSocketServer to loopback, document container binding

### DIFF
--- a/internal/claude/mcp_config.go
+++ b/internal/claude/mcp_config.go
@@ -164,16 +164,16 @@ func (r *Runner) createMCPConfigLocked(socketPath string) (string, error) {
 // Must be called with mu held.
 func (r *Runner) createContainerMCPConfigLocked(containerPort int) (string, error) {
 	// Bind to 0.0.0.0 inside the container (all interfaces) rather than a specific
-	// container IP. This is required for Docker's DNAT port forwarding (-p 0:21120)
-	// to route host connections to the container: Docker forwards to the container's
-	// eth0 IP, not loopback, so binding only to 127.0.0.1 would make the port
-	// unreachable from the host.
+	// container IP. This is required for Docker's DNAT port forwarding (for example,
+	// `-p 0:containerPort`) to route host connections to the container: Docker forwards
+	// to the container's eth0 IP, not loopback, so binding only to 127.0.0.1 would make
+	// the port unreachable from the host.
 	//
-	// Accepted risk: other containers on the same Docker bridge network could connect
-	// to port 21120. This is mitigated by Docker's default bridge isolation between
-	// sessions, short session lifetimes, and the MCP protocol requiring structured
-	// JSON that is not trivially exploitable. Restricting to a per-session bridge
-	// network would eliminate this risk but is a larger separate change.
+	// Accepted risk: other containers on the same Docker bridge network can typically
+	// connect to containerPort. This risk is partially mitigated by short session
+	// lifetimes and the MCP protocol requiring structured JSON that is not trivially
+	// exploitable. Using a per-session or otherwise isolated Docker network for each
+	// run would further reduce cross-container exposure but is a larger separate change.
 	listenAddr := fmt.Sprintf("0.0.0.0:%d", containerPort)
 	args := []string{"mcp-server", "--listen", listenAddr, "--auto-approve", "--session-id", r.sessionID}
 	if r.hostTools {

--- a/internal/mcp/socket.go
+++ b/internal/mcp/socket.go
@@ -170,8 +170,8 @@ func WithHostToolChannels(
 }
 
 // NewTCPSocketServer creates a socket server that listens on TCP instead of a
-// Unix socket. Used for container sessions where Unix sockets can't cross the
-// Docker container boundary.
+// Unix socket. This is a legacy/testing helper and is not used by current
+// production container sessions.
 //
 // Binds to 127.0.0.1 (loopback only). This function is legacy/unused in the
 // current production container flow: production sessions use a reversed-TCP

--- a/internal/mcp/socket_test.go
+++ b/internal/mcp/socket_test.go
@@ -460,6 +460,15 @@ func TestNewTCPSocketServer(t *testing.T) {
 		t.Error("TCPAddr() returned empty string")
 	}
 
+	// The listener must be bound to loopback only (security regression check)
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		t.Fatalf("failed to parse TCPAddr %q: %v", addr, err)
+	}
+	if !tcpAddr.IP.IsLoopback() {
+		t.Errorf("TCPAddr() = %q, want loopback address (127.0.0.1)", addr)
+	}
+
 	// TCPPort should return a positive port number
 	port := server.TCPPort()
 	if port <= 0 {


### PR DESCRIPTION
## Summary
Tightens the network binding for the host-side MCP TCP server to loopback-only and documents the accepted risk of the container-side `0.0.0.0` binding.

## Changes
- Restrict `NewTCPSocketServer` bind address from `0.0.0.0:0` to `127.0.0.1:0`, since the legacy host-listening TCP path is no longer used in production container flows
- Document why `createContainerMCPConfigLocked` still binds to `0.0.0.0` inside containers (Docker DNAT requires it) and the accepted risk of cross-container reachability on the bridge network
- Update comments to reflect the current reversed-TCP architecture

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify no regressions
- Verify container sessions still work end-to-end (MCP subprocess inside container listens, host dials in)
- Confirm `NewTCPSocketServer` binds only to loopback by inspecting listener address in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #367