### PR TITLE
fix(container): add runtime validation for version strings in Dockerfile generation

### DIFF
--- a/internal/container/build.go
+++ b/internal/container/build.go
@@ -22,6 +22,16 @@ func isValidVersion(v string) bool {
 	return validVersionRe.MatchString(v)
 }
 
+// validRustVersionRe matches well-formed Rust toolchain specs:
+//   - numeric releases:     "1.77", "1.77.0"
+//   - named channels:       "stable", "beta", "nightly"
+//   - date-pinned channels: "nightly-2024-01-01", "beta-2024-01-01"
+var validRustVersionRe = regexp.MustCompile(`^(?:\d+(?:\.\d+)*|(?:stable|beta|nightly)(?:-\d{4}-\d{2}-\d{2})?)$`)
+
+func isValidRustVersion(v string) bool {
+	return validRustVersionRe.MatchString(v)
+}
+
 // defaultVersions are used when a version cannot be parsed from the repo.
 var defaultVersions = map[Language]string{
 	LangGo:     "1.23",
@@ -162,7 +172,7 @@ func languageInstallBlock(l DetectedLang) (string, error) {
 		// Build dependencies only — mise handles the actual Python install.
 		return "RUN apk add --no-cache libffi-dev openssl-dev bzip2-dev xz-dev readline-dev sqlite-dev\n", nil
 	case LangRust:
-		if !isValidVersion(v) {
+		if !isValidRustVersion(v) {
 			return "", fmt.Errorf("invalid version string %q for language %s", v, l.Lang)
 		}
 		return fmt.Sprintf(""+

--- a/internal/container/build_test.go
+++ b/internal/container/build_test.go
@@ -726,6 +726,68 @@ func TestIsValidVersion(t *testing.T) {
 	}
 }
 
+func TestIsValidRustVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		valid   bool
+	}{
+		// Numeric releases
+		{"1.77", true},
+		{"1.77.0", true},
+		{"1.23", true},
+		// Named channels
+		{"stable", true},
+		{"beta", true},
+		{"nightly", true},
+		// Date-pinned channels
+		{"nightly-2024-01-01", true},
+		{"beta-2024-01-01", true},
+		// Invalid
+		{"", false},
+		{"stable && echo hi", false},
+		{"nightly; rm -rf /", false},
+		{"nightly-latest", false},
+		{"1.77 && evil", false},
+		{"abc", false},
+		{"1.", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := isValidRustVersion(tt.version)
+			if got != tt.valid {
+				t.Errorf("isValidRustVersion(%q) = %v, want %v", tt.version, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestGenerateDockerfile_RustChannelVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"stable channel", "stable"},
+		{"beta channel", "beta"},
+		{"nightly channel", "nightly"},
+		{"date-pinned nightly", "nightly-2024-01-01"},
+		{"date-pinned beta", "beta-2024-01-01"},
+		{"numeric version", "1.77.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			df, err := GenerateDockerfile([]DetectedLang{
+				{Lang: LangRust, Version: tt.version},
+			}, "0.2.11", "")
+			if err != nil {
+				t.Fatalf("unexpected error for Rust version %q: %v", tt.version, err)
+			}
+			if !strings.Contains(df, "--default-toolchain "+tt.version) {
+				t.Errorf("expected --default-toolchain %s in Dockerfile", tt.version)
+			}
+		})
+	}
+}
+
 func TestGenerateDockerfile_RejectsInvalidVersion(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary
Prevents shell injection via malicious version strings by validating all language versions before they are interpolated into Dockerfile `RUN` instructions.

## Changes
- Add `isValidVersion()` helper using a strict regex (`^\d+(?:\.\d+)*$`) that rejects anything containing shell metacharacters, letters, or other non-numeric separators
- Update `GenerateDockerfile`, `languageInstallBlock`, and `miseInstallBlock` to return errors on invalid versions instead of silently interpolating them
- Propagate the new error return through `EnsureImage` and all callers
- Add comprehensive tests for the validator, and rejection tests for every supported language (Go, Rust, Ruby, Python, Node, Java)

## Test plan
- `go test -p=1 -count=1 ./internal/container/...`
- New `TestIsValidVersion` covers valid formats (`"20"`, `"1.23"`, `"3.3.0"`) and injection attempts (`"1.23 && echo hi"`, `"3.3 ; rm -rf /"`, etc.)
- New `TestGenerateDockerfile_RejectsInvalidVersion` ensures end-to-end rejection for all language types
- New `TestLanguageInstallBlock_RejectsInvalidVersion` and `TestMiseInstallBlock_RejectsInvalidVersion` test the lower-level functions directly
- All existing tests updated for the new error return and continue to pass

Fixes #365