### PR TITLE
feat(dashboard): add Needs Attention section and Open Issue button

### DIFF
--- a/internal/dashboard/index.html
+++ b/internal/dashboard/index.html
@@ -131,6 +131,8 @@
   .summary-stat .value.accent { color: var(--accent); }
   .summary-stat .value.green { color: var(--green); }
   .summary-stat .value.cyan { color: var(--cyan); }
+  .summary-stat .value.yellow { color: var(--yellow); }
+  .summary-stat .value.red { color: var(--red); }
 
   /* Needs Attention section */
   .needs-attention-section {
@@ -506,8 +508,10 @@
     display: inline-flex;
     align-items: center;
   }
-  .ctrl-btn.issue:hover {
+  .ctrl-btn.issue:hover,
+  .ctrl-btn.issue:focus {
     background: rgba(167, 139, 250, 0.2);
+    text-decoration: none;
   }
   .ctrl-flash {
     font-family: var(--font-mono);
@@ -686,7 +690,11 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
   }
 
   function isAwaiting(item) {
-    return item.state === 'active' && item.current_step && item.current_step.startsWith('await_');
+    return (
+      item.state === 'active' &&
+      item.current_step &&
+      /(^|_)await_/.test(item.current_step)
+    );
   }
 
   function renderSummary() {
@@ -721,7 +729,7 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
       </div>
       ${totalAwaiting > 0 ? `<div class="summary-stat">
         <div class="label">Awaiting</div>
-        <div class="value" style="color:var(--yellow)">${totalAwaiting}</div>
+        <div class="value yellow">${totalAwaiting}</div>
       </div>` : ''}
       <div class="summary-stat">
         <div class="label">Queued</div>
@@ -733,7 +741,7 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
       </div>
       ${totalFailed > 0 ? `<div class="summary-stat">
         <div class="label">Failed</div>
-        <div class="value" style="color:var(--red)">${totalFailed}</div>
+        <div class="value red">${totalFailed}</div>
       </div>` : ''}
       <div class="summary-stat">
         <div class="label">Spend</div>
@@ -885,7 +893,7 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
     }
 
     const issueUrl = item.issue_ref && item.issue_ref.url;
-    if (issueUrl) {
+    if (issueUrl && /^https?:\/\//i.test(issueUrl)) {
       extraHtml += `<div class="item-pr"><a class="ctrl-btn issue" href="${escapeHtml(issueUrl)}" target="_blank" rel="noopener">Open Issue</a></div>`;
     }
 


### PR DESCRIPTION
## Summary
Enhances the dashboard to surface work items that need human attention (awaiting states) in a dedicated section, and adds a button to quickly open the source issue.

## Changes
- Add "Needs Attention" section that groups work items in `await_*` steps at the top of each daemon
- Show yellow "awaiting" badge and border for items in await states
- Display an "Awaiting" count in the summary bar when applicable
- Add "Open Issue" button on work item cards linking to the source issue URL

## Test plan
- Run `go test -p=1 -count=1 ./...` to verify no regressions
- Start the dashboard and verify items in `await_*` steps appear in the "Needs Attention" section with yellow styling
- Confirm the summary bar shows the "Awaiting" count only when > 0
- Verify the "Open Issue" button appears for items with an `issue_ref.url` and opens the correct link
- Check that non-awaiting items render normally in their usual section

Fixes #371