### PR TITLE
fix(daemon): detect CI regression during await_review

### DIFF
--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -90,12 +90,28 @@ func (c *eventChecker) checkPRReviewed(ctx context.Context, params *workflow.Par
 
 	if prState == git.PRStateMerged {
 		log.Info("PR was merged externally")
-		return true, map[string]any{"pr_merged_externally": true}, nil
+		return true, map[string]any{"pr_merged_externally": true, "ci_regressed": false}, nil
 	}
 
 	// If we're currently addressing feedback or pushing, don't poll for more
 	if item.Phase == "addressing_feedback" || item.Phase == "pushing" {
 		return false, nil, nil
+	}
+
+	// Check for CI regression — if CI is now failing while we're awaiting review,
+	// fire the event so the workflow can route back to the CI fix loop.
+	// This catches late-posting CI systems (e.g. CircleCI status contexts that
+	// arrive after the daemon has already advanced past await_ci) and CI that
+	// breaks due to upstream changes.
+	checkCI := params.Bool("check_ci", true)
+	if checkCI {
+		ciStatus, ciErr := d.gitService.CheckPRChecks(pollCtx, sess.RepoPath, item.Branch)
+		if ciErr != nil {
+			log.Debug("CI regression check failed, continuing with review check", "error", ciErr)
+		} else if ciStatus == git.CIStatusFailing {
+			log.Warn("CI regressed during review phase")
+			return true, map[string]any{"ci_regressed": true}, nil
+		}
 	}
 
 	workItem, ok := d.state.GetWorkItem(item.ID)
@@ -156,14 +172,14 @@ func (c *eventChecker) checkPRReviewed(ctx context.Context, params *workflow.Par
 
 	if reviewDecision == git.ReviewApproved {
 		log.Info("PR approved")
-		return true, map[string]any{"review_approved": true}, nil
+		return true, map[string]any{"review_approved": true, "ci_regressed": false}, nil
 	}
 
 	// When auto_address is disabled, fire the event for changes_requested so
 	// the workflow engine can route to an explicit address_review state.
 	if !autoAddress && reviewDecision == git.ReviewChangesRequested {
 		log.Info("PR has changes requested, advancing for address_review")
-		return true, map[string]any{"changes_requested": true}, nil
+		return true, map[string]any{"changes_requested": true, "ci_regressed": false}, nil
 	}
 
 	return false, nil, nil

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -312,6 +312,247 @@ func TestCheckPRReviewed_NoSession(t *testing.T) {
 	}
 }
 
+func TestCheckPRReviewed_CIRegressed(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// PR is OPEN
+	prStateJSON, _ := json.Marshal(struct {
+		State string `json:"state"`
+	}{State: "OPEN"})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Stdout: prStateJSON,
+	})
+
+	// CI is FAILING — gh pr checks returns non-zero with failure state
+	checksJSON, _ := json.Marshal([]struct {
+		State string `json:"state"`
+	}{{State: "SUCCESS"}, {State: "FAILURE"}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "checks"}, exec.MockResponse{
+		Stdout: checksJSON,
+		Err:    fmt.Errorf("exit status 1"),
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_review",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(nil)
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+
+	fired, data, err := checker.checkPRReviewed(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fired {
+		t.Error("expected fired=true when CI regressed")
+	}
+	if data == nil || data["ci_regressed"] != true {
+		t.Error("expected ci_regressed=true in data")
+	}
+}
+
+func TestCheckPRReviewed_CIPassing_NoRegression(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// PR is OPEN
+	prStateJSON, _ := json.Marshal(struct {
+		State string `json:"state"`
+	}{State: "OPEN"})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Stdout: prStateJSON,
+	})
+
+	// CI is passing
+	checksJSON, _ := json.Marshal([]struct {
+		State string `json:"state"`
+	}{{State: "SUCCESS"}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "checks"}, exec.MockResponse{
+		Stdout: checksJSON,
+	})
+
+	// No comments
+	prListJSON, _ := json.Marshal([]struct {
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
+		Comments    []any  `json:"comments"`
+		Reviews     []any  `json:"reviews"`
+	}{{State: "OPEN", HeadRefName: "feature-sess-1", Comments: []any{}, Reviews: []any{}}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "list"}, exec.MockResponse{
+		Stdout: prListJSON,
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_review",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(nil)
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+
+	fired, data, err := checker.checkPRReviewed(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fired {
+		t.Error("expected fired=false when CI is passing (no regression)")
+	}
+	if data != nil && data["ci_regressed"] == true {
+		t.Error("expected no ci_regressed when CI is passing")
+	}
+}
+
+func TestCheckPRReviewed_CIPending_NoRegression(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// PR is OPEN
+	prStateJSON, _ := json.Marshal(struct {
+		State string `json:"state"`
+	}{State: "OPEN"})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Stdout: prStateJSON,
+	})
+
+	// CI is pending — gh pr checks returns non-zero with pending state
+	checksJSON, _ := json.Marshal([]struct {
+		State string `json:"state"`
+	}{{State: "SUCCESS"}, {State: "PENDING"}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "checks"}, exec.MockResponse{
+		Stdout: checksJSON,
+		Err:    fmt.Errorf("exit status 1"),
+	})
+
+	// No comments
+	prListJSON, _ := json.Marshal([]struct {
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
+		Comments    []any  `json:"comments"`
+		Reviews     []any  `json:"reviews"`
+	}{{State: "OPEN", HeadRefName: "feature-sess-1", Comments: []any{}, Reviews: []any{}}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "list"}, exec.MockResponse{
+		Stdout: prListJSON,
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_review",
+	})
+
+	checker := newEventChecker(d)
+	params := workflow.NewParamHelper(nil)
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+
+	fired, data, err := checker.checkPRReviewed(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fired {
+		t.Error("expected fired=false when CI is pending (not a regression)")
+	}
+	if data != nil && data["ci_regressed"] == true {
+		t.Error("expected no ci_regressed when CI is pending")
+	}
+}
+
+func TestCheckPRReviewed_CICheckDisabled(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// PR is OPEN
+	prStateJSON, _ := json.Marshal(struct {
+		State string `json:"state"`
+	}{State: "OPEN"})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "view"}, exec.MockResponse{
+		Stdout: prStateJSON,
+	})
+
+	// CI is FAILING
+	checksJSON, _ := json.Marshal([]struct {
+		State string `json:"state"`
+	}{{State: "FAILURE"}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "checks"}, exec.MockResponse{
+		Stdout: checksJSON,
+		Err:    fmt.Errorf("exit status 1"),
+	})
+
+	// No comments
+	prListJSON, _ := json.Marshal([]struct {
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
+		Comments    []any  `json:"comments"`
+		Reviews     []any  `json:"reviews"`
+	}{{State: "OPEN", HeadRefName: "feature-sess-1", Comments: []any{}, Reviews: []any{}}})
+	mockExec.AddPrefixMatch("gh", []string{"pr", "list"}, exec.MockResponse{
+		Stdout: prListJSON,
+	})
+
+	d := testDaemonWithExec(cfg, mockExec)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&daemonstate.WorkItem{
+		ID:          "item-1",
+		IssueRef:    config.IssueRef{Source: "github", ID: "1"},
+		SessionID:   "sess-1",
+		Branch:      "feature-sess-1",
+		CurrentStep: "await_review",
+	})
+
+	checker := newEventChecker(d)
+	// Disable CI check
+	params := workflow.NewParamHelper(map[string]any{"check_ci": false})
+	itemTmp, _ := d.state.GetWorkItem("item-1")
+	view := d.workItemView(itemTmp)
+
+	fired, data, err := checker.checkPRReviewed(context.Background(), params, view)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fired {
+		t.Error("expected fired=false when check_ci is disabled (CI failure should be ignored)")
+	}
+	if data != nil && data["ci_regressed"] == true {
+		t.Error("expected no ci_regressed when check_ci is disabled")
+	}
+}
+
 func TestCheckCIComplete_CIPassing_AutoMergeEnabled(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)

--- a/internal/workflow/defaults.go
+++ b/internal/workflow/defaults.go
@@ -11,6 +11,7 @@ import (
 //	  → conflicting=true: rebase → await_ci (loop, bounded by max_rebase_rounds)
 //	    → rebase error: resolve_conflicts (Claude AI) → push_conflict_fix → await_ci
 //	  → ci_passed=true:   await_review → check_review_result
+//	    → ci_regressed=true:       await_ci (loop back to fix CI)
 //	    → review_approved=true:    merge → done
 //	    → changes_requested=true: address_review → push_review_fix → await_review (loop)
 //	  → ci_failed=true:   fix_ci → push_ci_fix → await_ci (loop)
@@ -138,6 +139,7 @@ func DefaultWorkflowConfig() *Config {
 				Type:        StateTypeChoice,
 				DisplayName: "Checking Review",
 				Choices: []ChoiceRule{
+					{Variable: "ci_regressed", Equals: true, Next: "await_ci"},
 					{Variable: "review_approved", Equals: true, Next: "merge"},
 					{Variable: "changes_requested", Equals: true, Next: "address_review"},
 					{Variable: "pr_merged_externally", Equals: true, Next: "done"},
@@ -514,8 +516,9 @@ func ReviewTemplateConfig() *TemplateConfig {
 		Template: "review",
 		Entry:    "await_review",
 		Exits: map[string]string{
-			"success": "review_done",
-			"failure": "review_failed",
+			"success":       "review_done",
+			"failure":       "review_failed",
+			"ci_regression": "review_ci_regressed",
 		},
 		Params: []TemplateParam{
 			{Name: "simplify", Default: false},
@@ -538,6 +541,7 @@ func ReviewTemplateConfig() *TemplateConfig {
 				Type:        StateTypeChoice,
 				DisplayName: "Checking Review",
 				Choices: []ChoiceRule{
+					{Variable: "ci_regressed", Equals: true, Next: "review_ci_regressed"},
 					{Variable: "review_approved", Equals: true, Next: "review_done"},
 					{Variable: "changes_requested", Equals: true, Next: "address_review"},
 					{Variable: "pr_merged_externally", Equals: true, Next: "review_done"},
@@ -580,6 +584,10 @@ func ReviewTemplateConfig() *TemplateConfig {
 			"review_failed": {
 				Type:        StateTypeFail,
 				DisplayName: "Failed",
+			},
+			"review_ci_regressed": {
+				Type:        StateTypeFail,
+				DisplayName: "CI Regressed",
 			},
 		},
 	}

--- a/internal/workflow/defaults_test.go
+++ b/internal/workflow/defaults_test.go
@@ -52,13 +52,22 @@ func TestDefaultWorkflowConfig(t *testing.T) {
 		t.Errorf("await_review next: expected check_review_result, got %s", review.Next)
 	}
 
-	// check_review_result routes review_approved → merge and changes_requested → address_review
+	// check_review_result routes ci_regressed → await_ci, review_approved → merge, changes_requested → address_review
 	checkReview := cfg.States["check_review_result"]
 	if checkReview == nil {
 		t.Fatal("expected check_review_result state")
 	}
 	if checkReview.Type != StateTypeChoice {
 		t.Errorf("check_review_result type: expected choice, got %s", checkReview.Type)
+	}
+	if len(checkReview.Choices) != 4 {
+		t.Errorf("check_review_result choices: expected 4, got %d", len(checkReview.Choices))
+	}
+	if len(checkReview.Choices) >= 1 {
+		first := checkReview.Choices[0]
+		if first.Variable != "ci_regressed" || first.Equals != true || first.Next != "await_ci" {
+			t.Errorf("first review choice: expected ci_regressed→await_ci, got %s=%v→%s", first.Variable, first.Equals, first.Next)
+		}
 	}
 
 	// address_review state
@@ -338,6 +347,36 @@ func TestDefaultWorkflowConfig_RetryOnNetworkStates(t *testing.T) {
 		if len(state.Retry) > 0 {
 			t.Errorf("state %q should NOT have retry configured (expensive action)", name)
 		}
+	}
+}
+
+func TestReviewTemplateConfig_CIRegressionExit(t *testing.T) {
+	tmpl := ReviewTemplateConfig()
+
+	// Verify ci_regression exit exists
+	if _, ok := tmpl.Exits["ci_regression"]; !ok {
+		t.Error("expected ci_regression exit in review template")
+	}
+
+	// Verify check_review_result has ci_regressed rule as first choice
+	checkReview := tmpl.States["check_review_result"]
+	if checkReview == nil {
+		t.Fatal("expected check_review_result state")
+	}
+	if len(checkReview.Choices) < 1 || checkReview.Choices[0].Variable != "ci_regressed" {
+		t.Error("expected first choice rule to be ci_regressed")
+	}
+	if checkReview.Choices[0].Next != "review_ci_regressed" {
+		t.Errorf("ci_regressed choice next: expected review_ci_regressed, got %s", checkReview.Choices[0].Next)
+	}
+
+	// Verify review_ci_regressed state exists and is a fail terminal
+	regState := tmpl.States["review_ci_regressed"]
+	if regState == nil {
+		t.Fatal("expected review_ci_regressed state in review template")
+	}
+	if regState.Type != StateTypeFail {
+		t.Errorf("review_ci_regressed type: expected fail, got %s", regState.Type)
 	}
 }
 


### PR DESCRIPTION
## Summary
- When external CI systems (e.g. CircleCI) post status contexts asynchronously, the daemon can advance past `await_ci` before all checks are reported — if a late-arriving check fails, the PR gets stuck in `await_review`
- `checkPRReviewed` now also checks CI status on each poll; if CI is failing, fires `ci_regressed=true` so the workflow routes back to `await_ci` for the normal fix loop
- Also handles CI breaking due to upstream changes to main while awaiting review

## Test plan
- [x] `TestCheckPRReviewed_CIRegressed` — CI failing fires `ci_regressed: true`
- [x] `TestCheckPRReviewed_CIPassing_NoRegression` — CI passing doesn't trigger
- [x] `TestCheckPRReviewed_CIPending_NoRegression` — CI pending doesn't trigger
- [x] `TestCheckPRReviewed_CICheckDisabled` — `check_ci: false` param skips the check
- [x] `TestReviewTemplateConfig_CIRegressionExit` — template has correct exit and state
- [x] `TestDefaultWorkflowConfig` — validates `ci_regressed` choice rule in `check_review_result`
- [x] Full test suite passes (`go test -p=1 -count=1 ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)