### PR TITLE
fix(daemon): use REST API for issue comments to get updatedAt

### DIFF
--- a/internal/daemon/actions_test.go
+++ b/internal/daemon/actions_test.go
@@ -8861,24 +8861,20 @@ func TestStartCoding_IncludesPlanFromIssueComments(t *testing.T) {
 		return name == "git" && len(args) >= 3 && args[0] == "rev-parse" && args[1] == "--verify"
 	}, exec.MockResponse{Err: fmt.Errorf("fatal: Needed a single revision")})
 
-	// Mock gh issue view --json comments to return a plan comment with the marker
-	commentsJSON, _ := json.Marshal(struct {
-		Comments []struct {
-			Author    struct{ Login string } `json:"author"`
-			Body      string                 `json:"body"`
-			CreatedAt string                 `json:"createdAt"`
-		} `json:"comments"`
+	// Mock gh api (REST) to return a plan comment with the marker.
+	// GetIssueComments uses the REST API because gh issue view --json comments
+	// does not include updatedAt in its response.
+	commentsJSON, _ := json.Marshal([]struct {
+		ID        int                    `json:"id"`
+		Body      string                 `json:"body"`
+		User      struct{ Login string } `json:"user"`
+		CreatedAt string                 `json:"created_at"`
+		UpdatedAt string                 `json:"updated_at"`
 	}{
-		Comments: []struct {
-			Author    struct{ Login string } `json:"author"`
-			Body      string                 `json:"body"`
-			CreatedAt string                 `json:"createdAt"`
-		}{
-			{Author: struct{ Login string }{"bot"}, Body: "## Plan\n1. Refactor the widget\n2. Add tests\n" + worker.PlanMarker, CreatedAt: "2026-03-05T10:00:00Z"},
-			{Author: struct{ Login string }{"zhubert"}, Body: "approved", CreatedAt: "2026-03-05T11:00:00Z"},
-		},
+		{ID: 100, Body: "## Plan\n1. Refactor the widget\n2. Add tests\n" + worker.PlanMarker, User: struct{ Login string }{"bot"}, CreatedAt: "2026-03-05T10:00:00Z", UpdatedAt: "2026-03-05T10:00:00Z"},
+		{ID: 101, Body: "approved", User: struct{ Login string }{"zhubert"}, CreatedAt: "2026-03-05T11:00:00Z", UpdatedAt: "2026-03-05T11:00:00Z"},
 	})
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -9604,9 +9600,9 @@ func TestStartCoding_SimplifyDirectiveAppended(t *testing.T) {
 	mockExec.AddRule(func(dir, name string, args []string) bool {
 		return name == "git" && len(args) >= 3 && args[0] == "rev-parse" && args[1] == "--verify"
 	}, exec.MockResponse{Err: fmt.Errorf("fatal: Needed a single revision")})
-	// Suppress gh issue view (fetching comments for plan)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
-		Stdout: []byte(`{"comments":[]}`),
+	// Suppress gh api (fetching comments for plan via REST API)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/"}, exec.MockResponse{
+		Stdout: []byte(`[]`),
 	})
 
 	gitSvc := git.NewGitServiceWithExecutor(mockExec)
@@ -9658,8 +9654,8 @@ func TestStartCoding_SimplifyDirectiveNotAppendedByDefault(t *testing.T) {
 	mockExec.AddRule(func(dir, name string, args []string) bool {
 		return name == "git" && len(args) >= 3 && args[0] == "rev-parse" && args[1] == "--verify"
 	}, exec.MockResponse{Err: fmt.Errorf("fatal: Needed a single revision")})
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
-		Stdout: []byte(`{"comments":[]}`),
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/"}, exec.MockResponse{
+		Stdout: []byte(`[]`),
 	})
 
 	gitSvc := git.NewGitServiceWithExecutor(mockExec)

--- a/internal/daemon/coding.go
+++ b/internal/daemon/coding.go
@@ -51,7 +51,7 @@ func (d *Daemon) fetchIssueComments(ctx context.Context, repoPath string, item d
 		}
 		result := make([]issues.IssueComment, len(gitComments))
 		for i, gc := range gitComments {
-			result[i] = issues.IssueComment{Author: gc.Author, Body: gc.Body, CreatedAt: gc.CreatedAt}
+			result[i] = issues.IssueComment{Author: gc.Author, Body: gc.Body, CreatedAt: gc.CreatedAt, UpdatedAt: gc.UpdatedAt}
 		}
 		return result, nil
 	}

--- a/internal/daemon/events.go
+++ b/internal/daemon/events.go
@@ -21,6 +21,11 @@ import (
 // handles upserted comments whose CreatedAt is stale — without this,
 // re-planning loops would use the frozen CreatedAt as cutoff, causing
 // already-consumed feedback to re-trigger indefinitely.
+//
+// This function depends on UpdatedAt being populated correctly by all comment
+// sources. If UpdatedAt is zero (e.g. because the provider doesn't return it),
+// the cutoff falls back to the stale CreatedAt and the re-planning loop recurs.
+// See the IssueComment doc in issues/provider.go for provider-specific notes.
 func systemCommentCutoff(stepEnteredAt time.Time, comments []issues.IssueComment) time.Time {
 	cutoff := stepEnteredAt
 	var latestSystem time.Time

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -1863,8 +1863,8 @@ func TestCheckGateApproved_CommentMatch_Fires(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Comment posted 5 minutes after step was entered — should fire.
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"reviewer"},"body":"/approve please proceed","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"/approve please proceed","user":{"login":"reviewer"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -1911,8 +1911,8 @@ func TestCheckGateApproved_CommentMatch_OldCommentIgnored(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Comment posted 5 minutes BEFORE step was entered — should be ignored.
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"oldreviewer"},"body":"/approve old comment","createdAt":"2020-01-01T09:55:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"/approve old comment","user":{"login":"oldreviewer"},"created_at":"2020-01-01T09:55:00Z","updated_at":"2020-01-01T09:55:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -1951,8 +1951,8 @@ func TestCheckGateApproved_CommentMatch_NoMatch(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"user"},"body":"just a regular comment","createdAt":"2020-01-01T10:00:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"just a regular comment","user":{"login":"user"},"created_at":"2020-01-01T10:00:00Z","updated_at":"2020-01-01T10:00:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2152,8 +2152,8 @@ func TestCheckGateApproved_CommentMatch_NonCollaboratorIgnored(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Matching comment from a non-collaborator.
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"outsider"},"body":"/approve please","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"/approve please","user":{"login":"outsider"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 	// Collaborator check for "outsider" returns 404 (not a collaborator).
@@ -2196,8 +2196,8 @@ func TestCheckGateApproved_CommentMatch_CollaboratorApproves(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Matching comment from a collaborator.
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"contributor"},"body":"/approve looks good","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"/approve looks good","user":{"login":"contributor"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 	// Collaborator check for "contributor" succeeds (HTTP 204 → no error).
@@ -2506,8 +2506,8 @@ func TestCheckPlanUserReplied_FiresOnNewComment(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Comment posted after step entry
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"alice"},"body":"Can you add more detail about the error handling?","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"Can you add more detail about the error handling?","user":{"login":"alice"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2554,8 +2554,8 @@ func TestCheckPlanUserReplied_ApprovalPatternMatches(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"bob"},"body":"LGTM, proceed with implementation","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"LGTM, proceed with implementation","user":{"login":"bob"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2599,8 +2599,8 @@ func TestCheckPlanUserReplied_ApprovalPatternNoMatch(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"carol"},"body":"What about error handling?","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"What about error handling?","user":{"login":"carol"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2642,8 +2642,8 @@ func TestCheckPlanUserReplied_NonCollaboratorCannotApprovePlan(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Matching comment from a non-collaborator.
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"outsider"},"body":"LGTM, ship it","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"LGTM, ship it","user":{"login":"outsider"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 	// Collaborator check for "outsider" returns 404 (not a collaborator).
@@ -2693,8 +2693,8 @@ func TestCheckPlanUserReplied_CollaboratorCanApprovePlan(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Matching comment from a collaborator.
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"contributor"},"body":"LGTM, proceed","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"LGTM, proceed","user":{"login":"contributor"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 	// Collaborator check for "contributor" succeeds (HTTP 204 → no error).
@@ -2743,8 +2743,8 @@ func TestCheckPlanUserReplied_OldCommentIgnored(t *testing.T) {
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Comment posted BEFORE step was entered
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"dave"},"body":"old comment","createdAt":"2020-01-01T09:55:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"old comment","user":{"login":"dave"},"created_at":"2020-01-01T09:55:00Z","updated_at":"2020-01-01T09:55:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2782,8 +2782,8 @@ func TestCheckPlanUserReplied_NoComments(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
-	commentsJSON := []byte(`{"comments":[]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2885,7 +2885,7 @@ func TestCheckPlanUserReplied_CLIError(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Err: fmt.Errorf("gh: not found"),
 	})
 
@@ -2924,8 +2924,8 @@ func TestCheckPlanUserReplied_InvalidApprovalPattern(t *testing.T) {
 
 	// Comment exists but approval_pattern is invalid regex — should still fire
 	// with plan_approved=false (pattern treated as absent).
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"eve"},"body":"looks good to me","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"looks good to me","user":{"login":"eve"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -2990,8 +2990,8 @@ func TestCheckEvent_PlanUserReplied_Routed(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
-	commentsJSON := []byte(`{"comments":[{"author":{"login":"frank"},"body":"Please reconsider the approach","createdAt":"2020-01-01T10:05:00Z"}]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[{"id":100,"body":"Please reconsider the approach","user":{"login":"frank"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 
@@ -4155,25 +4155,26 @@ func TestCheckGateApproved_UpsertedSystemCommentNoCutoffRegression(t *testing.T)
 }
 
 // TestCheckPlanUserReplied_GitHubUpdatedAtParsed is a GitHub-path regression
-// test that verifies updatedAt is parsed from gh issue view JSON and used in
-// the cutoff calculation. This exercises the full path from JSON parsing
-// through to event checking.
+// test that verifies updated_at is parsed from the REST API and used in
+// the cutoff calculation. GetIssueComments delegates to GetIssueCommentsWithIDs
+// which uses `gh api` (REST) because `gh issue view --json comments` does not
+// include updatedAt in its response.
 func TestCheckPlanUserReplied_GitHubUpdatedAtParsed(t *testing.T) {
 	cfg := testConfig()
 	mockExec := exec.NewMockExecutor(nil)
 
 	// Simulate a re-plan scenario with upserted system comment:
-	//   - Plan comment: createdAt = 10:00 (original), updatedAt = 10:10 (upserted)
-	//   - User feedback: createdAt = 10:05 (already consumed by first re-plan)
+	//   - Plan comment: created_at = 10:00 (original), updated_at = 10:10 (upserted)
+	//   - User feedback: created_at = 10:05 (already consumed by first re-plan)
 	//   - StepEnteredAt = 10:11 (after re-plan completed)
 	//
 	// Without UpdatedAt: cutoff = 10:00 (stale CreatedAt) → feedback at 10:05 re-triggers (BUG)
 	// With UpdatedAt:    cutoff = 10:10 (fresh UpdatedAt) → feedback at 10:05 is filtered (FIXED)
-	commentsJSON := []byte(`{"comments":[
-		{"author":{"login":"erg-bot"},"body":"Revised plan.\n<!-- erg:plan -->","createdAt":"2020-01-01T10:00:00Z","updatedAt":"2020-01-01T10:10:00Z"},
-		{"author":{"login":"alice"},"body":"Please also update docs/","createdAt":"2020-01-01T10:05:00Z","updatedAt":"2020-01-01T10:05:00Z"}
-	]}`)
-	mockExec.AddPrefixMatch("gh", []string{"issue", "view"}, exec.MockResponse{
+	commentsJSON := []byte(`[
+		{"id":100,"body":"Revised plan.\n<!-- erg:plan -->","user":{"login":"erg-bot"},"created_at":"2020-01-01T10:00:00Z","updated_at":"2020-01-01T10:10:00Z"},
+		{"id":101,"body":"Please also update docs/","user":{"login":"alice"},"created_at":"2020-01-01T10:05:00Z","updated_at":"2020-01-01T10:05:00Z"}
+	]`)
+	mockExec.AddPrefixMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, exec.MockResponse{
 		Stdout: commentsJSON,
 	})
 

--- a/internal/git/github.go
+++ b/internal/git/github.go
@@ -446,6 +446,15 @@ func (s *GitService) fetchInlineReviewComments(ctx context.Context, repoPath str
 }
 
 // IssueComment represents a single comment on a GitHub issue.
+// IssueComment represents a comment on a GitHub issue.
+//
+// IMPORTANT: UpdatedAt is critical for preventing infinite re-planning loops.
+// When plan comments are edited (upserted), CreatedAt stays frozen at the
+// original post time, but UpdatedAt advances. Without UpdatedAt, the daemon's
+// cutoff logic uses the stale CreatedAt and re-triggers on already-consumed
+// feedback forever. This field MUST be populated — `gh issue view --json
+// comments` does NOT return updatedAt, so callers must use the REST API
+// (gh api) which returns updated_at. See GetIssueComments.
 type IssueComment struct {
 	Author    string    // GitHub username
 	Body      string    // Comment text
@@ -493,42 +502,23 @@ func (s *GitService) CheckUserIsCollaborator(ctx context.Context, repoPath, user
 	return err == nil, nil
 }
 
-// GetIssueComments fetches all comments on a GitHub issue using the gh CLI.
-// Uses `gh issue view --json comments` to retrieve the full comment list.
+// GetIssueComments fetches all comments on a GitHub issue using the REST API.
+// Uses `gh api` instead of `gh issue view --json comments` because the latter
+// does not include updatedAt in its response, which is needed by
+// systemCommentCutoff to detect edited comments and prevent re-planning loops.
 func (s *GitService) GetIssueComments(ctx context.Context, repoPath string, issueNumber int) ([]IssueComment, error) {
-	output, err := s.executor.Output(ctx, repoPath, "gh", "issue", "view",
-		fmt.Sprintf("%d", issueNumber),
-		"--json", "comments",
-	)
+	withIDs, err := s.GetIssueCommentsWithIDs(ctx, repoPath, issueNumber)
 	if err != nil {
-		return nil, fmt.Errorf("gh issue view --json comments failed: %w", err)
+		return nil, err
 	}
-
-	var result struct {
-		Comments []struct {
-			Author struct {
-				Login string `json:"login"`
-			} `json:"author"`
-			Body      string    `json:"body"`
-			CreatedAt time.Time `json:"createdAt"`
-			UpdatedAt time.Time `json:"updatedAt"`
-		} `json:"comments"`
-	}
-	if err := json.Unmarshal(output, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse issue comments: %w", err)
-	}
-
-	comments := make([]IssueComment, 0, len(result.Comments))
-	for _, c := range result.Comments {
-		if c.Body == "" {
-			continue
-		}
-		comments = append(comments, IssueComment{
-			Author:    c.Author.Login,
+	comments := make([]IssueComment, len(withIDs))
+	for i, c := range withIDs {
+		comments[i] = IssueComment{
+			Author:    c.Author,
 			Body:      c.Body,
 			CreatedAt: c.CreatedAt,
 			UpdatedAt: c.UpdatedAt,
-		})
+		}
 	}
 	return comments, nil
 }

--- a/internal/git/github_test.go
+++ b/internal/git/github_test.go
@@ -2381,11 +2381,12 @@ func TestCheckIssueHasLabel_InvalidJSON(t *testing.T) {
 
 func TestGetIssueComments_MultipleComments(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("gh", []string{"issue", "view", "42", "--json", "comments"}, pexec.MockResponse{
-		Stdout: []byte(`{"comments":[
-			{"author":{"login":"alice"},"body":"/approve","createdAt":"2024-01-02T10:00:00Z"},
-			{"author":{"login":"bob"},"body":"looks good","createdAt":"2024-01-02T11:00:00Z"}
-		]}`),
+	// GetIssueComments now delegates to GetIssueCommentsWithIDs (REST API)
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, pexec.MockResponse{
+		Stdout: []byte(`[
+			{"id":1,"body":"/approve","user":{"login":"alice"},"created_at":"2024-01-02T10:00:00Z","updated_at":"2024-01-02T10:00:00Z"},
+			{"id":2,"body":"looks good","user":{"login":"bob"},"created_at":"2024-01-02T11:00:00Z","updated_at":"2024-01-02T12:00:00Z"}
+		]`),
 	})
 
 	svc := NewGitServiceWithExecutor(mock)
@@ -2405,12 +2406,19 @@ func TestGetIssueComments_MultipleComments(t *testing.T) {
 	if comments[1].Author != "bob" {
 		t.Errorf("expected bob, got %s", comments[1].Author)
 	}
+	// Verify UpdatedAt is populated (the whole point of this change)
+	if comments[1].UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be populated")
+	}
+	if !comments[1].UpdatedAt.After(comments[1].CreatedAt) {
+		t.Error("expected UpdatedAt to be after CreatedAt for edited comment")
+	}
 }
 
 func TestGetIssueComments_EmptyComments(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("gh", []string{"issue", "view", "5", "--json", "comments"}, pexec.MockResponse{
-		Stdout: []byte(`{"comments":[]}`),
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/issues/5/comments"}, pexec.MockResponse{
+		Stdout: []byte(`[]`),
 	})
 
 	svc := NewGitServiceWithExecutor(mock)
@@ -2425,11 +2433,11 @@ func TestGetIssueComments_EmptyComments(t *testing.T) {
 
 func TestGetIssueComments_EmptyBodiesExcluded(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("gh", []string{"issue", "view", "7", "--json", "comments"}, pexec.MockResponse{
-		Stdout: []byte(`{"comments":[
-			{"author":{"login":"bot"},"body":"","createdAt":"2024-01-01T00:00:00Z"},
-			{"author":{"login":"user"},"body":"real comment","createdAt":"2024-01-01T01:00:00Z"}
-		]}`),
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/issues/7/comments"}, pexec.MockResponse{
+		Stdout: []byte(`[
+			{"id":1,"body":"","user":{"login":"bot"},"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"},
+			{"id":2,"body":"real comment","user":{"login":"user"},"created_at":"2024-01-01T01:00:00Z","updated_at":"2024-01-01T01:00:00Z"}
+		]`),
 	})
 
 	svc := NewGitServiceWithExecutor(mock)
@@ -2448,7 +2456,7 @@ func TestGetIssueComments_EmptyBodiesExcluded(t *testing.T) {
 
 func TestGetIssueComments_CLIError(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("gh", []string{"issue", "view", "42", "--json", "comments"}, pexec.MockResponse{
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, pexec.MockResponse{
 		Err: fmt.Errorf("not found"),
 	})
 
@@ -2464,7 +2472,7 @@ func TestGetIssueComments_CLIError(t *testing.T) {
 
 func TestGetIssueComments_InvalidJSON(t *testing.T) {
 	mock := pexec.NewMockExecutor(nil)
-	mock.AddExactMatch("gh", []string{"issue", "view", "42", "--json", "comments"}, pexec.MockResponse{
+	mock.AddExactMatch("gh", []string{"api", "repos/:owner/:repo/issues/42/comments"}, pexec.MockResponse{
 		Stdout: []byte(`not json`),
 	})
 

--- a/internal/issues/asana.go
+++ b/internal/issues/asana.go
@@ -477,11 +477,12 @@ func (p *AsanaProvider) CheckIssueHasLabel(ctx context.Context, repoPath string,
 
 // asanaStory represents a single story (comment) on an Asana task.
 type asanaStory struct {
-	GID       string `json:"gid"`
-	Type      string `json:"type"`
-	Text      string `json:"text"`
-	CreatedAt string `json:"created_at"`
-	CreatedBy struct {
+	GID        string `json:"gid"`
+	Type       string `json:"type"`
+	Text       string `json:"text"`
+	CreatedAt  string `json:"created_at"`
+	ModifiedAt string `json:"modified_at"`
+	CreatedBy  struct {
 		Name string `json:"name"`
 	} `json:"created_by"`
 }
@@ -499,7 +500,7 @@ func (p *AsanaProvider) GetIssueComments(ctx context.Context, repoPath string, i
 		return nil, secrets.TokenNotFoundError(asanaPATEnvVar)
 	}
 
-	url := fmt.Sprintf("%s/tasks/%s/stories?opt_fields=gid,type,text,created_at,created_by.name", p.apiBase, issueID)
+	url := fmt.Sprintf("%s/tasks/%s/stories?opt_fields=gid,type,text,created_at,modified_at,created_by.name", p.apiBase, issueID)
 
 	var storiesResp asanaStoriesResponse
 	if err := apiRequest(ctx, p.httpClient, http.MethodGet, url, nil,
@@ -516,11 +517,13 @@ func (p *AsanaProvider) GetIssueComments(ctx context.Context, repoPath string, i
 			continue
 		}
 		createdAt, _ := time.Parse(time.RFC3339Nano, story.CreatedAt)
+		modifiedAt, _ := time.Parse(time.RFC3339Nano, story.ModifiedAt)
 		comments = append(comments, IssueComment{
 			ID:        story.GID,
 			Author:    story.CreatedBy.Name,
 			Body:      translateMarkersFromAsana(story.Text),
 			CreatedAt: createdAt,
+			UpdatedAt: modifiedAt,
 		})
 	}
 	return comments, nil

--- a/internal/issues/github.go
+++ b/internal/issues/github.go
@@ -117,6 +117,7 @@ func (p *GitHubProvider) GetIssueComments(ctx context.Context, repoPath string, 
 			Author:    gc.Author,
 			Body:      gc.Body,
 			CreatedAt: gc.CreatedAt,
+			UpdatedAt: gc.UpdatedAt,
 		}
 	}
 	return comments, nil

--- a/internal/issues/linear.go
+++ b/internal/issues/linear.go
@@ -335,6 +335,7 @@ const linearIssueCommentsQuery = `query($id: String!) {
         id
         body
         createdAt
+        updatedAt
         user {
           name
         }
@@ -352,6 +353,7 @@ type linearIssueCommentsResponse struct {
 					ID        string `json:"id"`
 					Body      string `json:"body"`
 					CreatedAt string `json:"createdAt"`
+					UpdatedAt string `json:"updatedAt"`
 					User      struct {
 						Name string `json:"name"`
 					} `json:"user"`
@@ -376,11 +378,13 @@ func (p *LinearProvider) GetIssueComments(ctx context.Context, repoPath string, 
 			continue
 		}
 		createdAt, _ := time.Parse(time.RFC3339Nano, n.CreatedAt)
+		updatedAt, _ := time.Parse(time.RFC3339Nano, n.UpdatedAt)
 		comments = append(comments, IssueComment{
 			ID:        n.ID,
 			Author:    n.User.Name,
 			Body:      n.Body,
 			CreatedAt: createdAt,
+			UpdatedAt: updatedAt,
 		})
 	}
 	return comments, nil

--- a/internal/issues/linear_test.go
+++ b/internal/issues/linear_test.go
@@ -788,6 +788,7 @@ func TestLinearProvider_GetIssueComments_ReturnsComments(t *testing.T) {
 			ID        string `json:"id"`
 			Body      string `json:"body"`
 			CreatedAt string `json:"createdAt"`
+			UpdatedAt string `json:"updatedAt"`
 			User      struct {
 				Name string `json:"name"`
 			} `json:"user"`
@@ -841,6 +842,7 @@ func TestLinearProvider_GetIssueComments_MillisecondTimestamps(t *testing.T) {
 			ID        string `json:"id"`
 			Body      string `json:"body"`
 			CreatedAt string `json:"createdAt"`
+			UpdatedAt string `json:"updatedAt"`
 			User      struct {
 				Name string `json:"name"`
 			} `json:"user"`
@@ -881,6 +883,7 @@ func TestLinearProvider_GetIssueComments_EmptyBodyExcluded(t *testing.T) {
 			ID        string `json:"id"`
 			Body      string `json:"body"`
 			CreatedAt string `json:"createdAt"`
+			UpdatedAt string `json:"updatedAt"`
 			User      struct {
 				Name string `json:"name"`
 			} `json:"user"`

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -115,6 +115,18 @@ func (r *ProviderRegistry) AllProviders() []Provider {
 }
 
 // IssueComment represents a comment on an issue from any supported source.
+//
+// IMPORTANT: UpdatedAt MUST be populated by all providers. It is used by
+// systemCommentCutoff to detect upserted (edited) plan comments and prevent
+// infinite re-planning loops. When a plan comment is edited in place,
+// CreatedAt stays frozen but UpdatedAt advances — without it the cutoff
+// uses the stale CreatedAt and already-consumed feedback re-triggers forever.
+//
+// Provider notes:
+//   - GitHub: `gh issue view --json comments` does NOT return updatedAt;
+//     use the REST API (gh api) which returns updated_at.
+//   - Asana: request the `modified_at` opt_field on stories.
+//   - Linear: include `updatedAt` in the GraphQL comments query.
 type IssueComment struct {
 	ID        string    // Provider-specific comment identifier (for updates; empty if not supported)
 	Author    string    // Username or display name


### PR DESCRIPTION
## Summary

- `gh issue view --json comments` does not include `updatedAt` in its response — the field simply isn't there. This meant `UpdatedAt` was always zero, `systemCommentCutoff` fell back to the stale `CreatedAt` of upserted plan comments, and already-consumed feedback kept re-triggering re-plans forever.
- Switched GitHub's `GetIssueComments` to use the REST API (`gh api`) which returns `updated_at`
- Added `modified_at` to Asana stories query and `updatedAt` to Linear GraphQL comments query
- Fixed two call sites (`coding.go`, `issues/github.go`) that omitted `UpdatedAt` when mapping comment structs
- Added documentation on `IssueComment` types and `systemCommentCutoff` about the `gh` CLI deficiency

## Test plan

- [x] All existing tests updated and passing
- [x] Existing regression test (`TestCheckPlanUserReplied_GitHubUpdatedAtParsed`) now exercises the REST API path
- [x] `go test -p=1 -count=1 ./...` passes (all 25 packages)
- [ ] Manual: trigger a plan, post feedback, verify re-plan happens once and stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)