### PR TITLE
fix(dashboard): replace 'Loading logs...' placeholder when logs arrive

### DIFF
--- a/internal/dashboard/index.html
+++ b/internal/dashboard/index.html
@@ -1016,16 +1016,17 @@ var Idiomorph=function(){"use strict";let o=new Set;let n={morphStyle:"outerHTML
   // Derives "previously rendered count" from logCache to avoid redundant state.
   function updateLogViewer(container, prevCacheLen, lines) {
     let lv = container.querySelector('.log-viewer');
+    const isPlaceholder = lv && lv.querySelector('.log-loading');
 
     if (!lines || lines.length === 0) {
-      if (!lv) {
+      if (!lv || isPlaceholder) {
         container.innerHTML = logPlaceholder('No output yet');
       }
       return;
     }
 
-    // If no existing viewer, or line count decreased (log rotation), do a full render
-    if (!lv || lines.length < prevCacheLen) {
+    // If no existing viewer, placeholder, or line count decreased (log rotation), do a full render
+    if (!lv || isPlaceholder || lines.length < prevCacheLen) {
       let html = '<div class="log-viewer">';
       for (const line of lines) {
         html += renderLogLine(line);


### PR DESCRIPTION
## Summary
Fixes the dashboard log viewer to properly replace the "Loading logs..." placeholder with actual log content when it becomes available.

## Changes
- Detect when the log viewer contains a `.log-loading` placeholder element
- Treat the placeholder state the same as having no viewer, so arriving logs trigger a full render instead of being silently ignored
- Also show "No output yet" when the placeholder is present but no lines are available

## Test plan
- Open the dashboard and observe a session that is starting up
- Verify the "Loading logs..." message appears initially
- Verify that once logs arrive, they replace the placeholder instead of leaving it stuck

Fixes #406