### PR TITLE
fix(docs): update dashboard title to 'erg orchestrator dashboard'

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -1206,7 +1206,7 @@
           <div class="sim-label">live simulation</div>
           <div class="sim-header">
             <div class="sim-header-left">
-              <h3><span>erg</span> dashboard</h3>
+              <h3><span>erg</span> orchestrator dashboard</h3>
             </div>
             <div class="sim-conn">
               <div class="sim-conn-dot"></div>


### PR DESCRIPTION
## Summary
Updates the dashboard simulation title in the docs to say "erg orchestrator dashboard" instead of "erg dashboard" for consistent branding.

## Changes
- Updated the `<h3>` title in `docs/dashboard.html` from "erg dashboard" to "erg orchestrator dashboard"

## Test plan
- Open `docs/dashboard.html` in a browser and verify the simulation header displays "erg orchestrator dashboard"

Fixes #412